### PR TITLE
Fixes type returned by index function

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -32,3 +32,7 @@ export const features: FeaturesList = {
   pubsub,
   storage,
 };
+
+export interface TestFeatureList extends FeaturesList {
+  cleanup();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { merge } from 'lodash';
 
 import { FirebaseFunctionsTest } from './lifecycle';
 import { features as lazyFeatures, FeaturesList } from './features';
+import { TestFeatureList } from './features';
 
 export = (firebaseConfig?: AppOptions) => {
   const test = new FirebaseFunctionsTest();
@@ -35,5 +36,5 @@ export = (firebaseConfig?: AppOptions) => {
   features = merge({}, features, {
     cleanup: () => test.cleanup,
   });
-  return features;
+  return features as TestFeatureList;
 };


### PR DESCRIPTION
### Description

I believe this fixes issue #7. I have been in conversation with the Firebase support team about this. Below is a super simple example of the issue I sent them.

### Code sample

Before the following code would throw an error `error TS2339: Property 'cleanup' does not exist on type 'FeaturesList'.`

```
import * as functionsTest from 'firebase-functions-test'
const test = functionsTest()
test.cleanup()
```

Now with the new type `TestFeatureList` the `cleanup` function exists on the return type of  `functionsTest()` and the code compiles and runs as expected.