### PR TITLE
Fix bug where setting service account key file location wasn't working

### DIFF
--- a/spec/app.spec.ts
+++ b/spec/app.spec.ts
@@ -29,8 +29,10 @@ import { FirebaseFunctionsTest } from '../src/lifecycle';
 
 describe('app', () => {
   let appInstance;
-  let test = new FirebaseFunctionsTest();
+  let test;
+
   before(() => {
+    test = new FirebaseFunctionsTest();
     test.init();
     appInstance = testApp();
   });

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -32,18 +32,18 @@ describe('index', () => {
   });
 
   it('should export the expected functions and namespaces', () => {
-    expect(Object.getOwnPropertyNames(indexExport)).to.deep.equal([
-      'mockConfig',
-      'wrap',
-      'makeChange',
+    expect(Object.getOwnPropertyNames(indexExport).sort()).to.deep.equal([
       'analytics',
       'auth',
+      'cleanup',
       'crashlytics',
       'database',
       'firestore',
+      'makeChange',
+      'mockConfig',
       'pubsub',
       'storage',
-      'cleanup',
+      'wrap',
     ]);
   });
 

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -21,37 +21,47 @@
 // SOFTWARE.
 
 import 'mocha';
-import './lifecycle.spec';
-import './main.spec';
-import './app.spec';
 import { expect } from 'chai';
 
-/* tslint:disable-next-line:no-var-requires */
-const indexExport = require('../src')();
-
 describe('index', () => {
+  /* tslint:disable-next-line:no-var-requires */
+  const indexExport = require('../src')({ projectId: 'fakeProject' }, 'fakeServiceAccount');
   after(() => {
     // Call cleanup (handles case of cleanup function not existing)
     indexExport.cleanup && indexExport.cleanup();
   });
 
-  it('should export wrap as a function', () => {
-    expect(indexExport.wrap).to.be.an('function');
+  it('should export the expected functions and namespaces', () => {
+    expect(Object.getOwnPropertyNames(indexExport)).to.deep.equal([
+      'mockConfig',
+      'wrap',
+      'makeChange',
+      'analytics',
+      'auth',
+      'crashlytics',
+      'database',
+      'firestore',
+      'pubsub',
+      'storage',
+      'cleanup',
+    ]);
   });
 
-  it('should export makeChange as a function', () => {
-    expect(indexExport.makeChange).to.be.an('function');
+  it('should set env variables based parameters SDK was initialized with', () => {
+    expect(process.env.FIREBASE_CONFIG).to.equal(JSON.stringify({ projectId: 'fakeProject' }));
+    expect(process.env.GOOGLE_APPLICATION_CREDENTIALS).to.equal('fakeServiceAccount');
   });
 
-  it('should export mockConfig as a function', () => {
-    expect(indexExport.mockConfig).to.be.an('function');
-  });
-
-  it('should export cleanup as a function', () => {
-    expect(indexExport.cleanup).to.be.an('function');
+  it('should clean up env variables once cleanup is called', () => {
+    indexExport.cleanup();
+    expect(process.env.FIREBASE_CONFIG).to.equal(undefined);
+    expect(process.env.GOOGLE_APPLICATION_CREDENTIALS).to.equal(undefined);
   });
 });
 
+import './lifecycle.spec';
+import './main.spec';
+import './app.spec';
 // import './providers/analytics.spec';
 // import './providers/auth.spec';
 // import './providers/database.spec';

--- a/spec/lifecycle.spec.ts
+++ b/spec/lifecycle.spec.ts
@@ -28,7 +28,12 @@ import { afterEach } from 'mocha';
 
 describe('lifecycle', () => {
   describe('#init', () => {
-    let test = new FirebaseFunctionsTest();
+    let test;
+
+    before(() => {
+      test = new FirebaseFunctionsTest();
+    });
+
     afterEach(() => {
       test.cleanup();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,14 +26,14 @@ import { merge } from 'lodash';
 import { FirebaseFunctionsTest } from './lifecycle';
 import { features as lazyFeatures, FeaturesList } from './features';
 
-export = (firebaseConfig?: AppOptions) => {
+export = (firebaseConfig?: AppOptions, pathToServiceAccountKey?: string) => {
   const test = new FirebaseFunctionsTest();
-  test.init(firebaseConfig);
+  test.init(firebaseConfig, pathToServiceAccountKey);
   // Ensure other files get loaded after init function, since they load `firebase-functions`
   // which will issue warning if process.env.FIREBASE_CONFIG is not yet set.
   let features = require('./features').features as typeof lazyFeatures;
   features = merge({}, features, {
-    cleanup: () => test.cleanup,
+    cleanup: () => test.cleanup(),
   });
   return features;
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

Fix 2 bugs in index.ts:
- top level export was actually missing the service account path parameter, which the init function in lifecycle.ts has.
- the cleanup function didn't work properly

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
