### PR TITLE
Added support for Timestamp and DocumentReference

### DIFF
--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -162,8 +162,8 @@ export function objectToValueProto(data: object) {
       };
     }
     if (val instanceof firestore.DocumentReference) {
-      const projectId: string = 'projectId'; // Determine project id
-      const database: string = '(default)'; // Determine database
+      const projectId: string = get(val, '_referencePath.projectId');
+      const database: string = get(val, '_referencePath.databaseId');
       const referenceValue: string = [
         'projects', projectId,
         'databases', database,

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -161,6 +161,21 @@ export function objectToValueProto(data: object) {
         bytesValue: val,
       };
     }
+    if (val instanceof firestore.DocumentReference) {
+      const projectId: string = 'projectId'; // Determine project id
+      const database: string = '(default)'; // Determine database
+      const referenceValue: string = [
+        'projects', projectId,
+        'databases', database,
+        val.path,
+      ].join('/');
+      return { referenceValue };
+    }
+    if (val instanceof firestore.Timestamp) {
+      return {
+        timestampValue: val.toDate().toISOString(),
+      };
+    }
     if (isPlainObject(val)) {
       return {
         mapValue: {
@@ -170,7 +185,7 @@ export function objectToValueProto(data: object) {
     }
     throw new Error(
       'Cannot encode ' + val + 'to a Firestore Value.' +
-      ' Local testing does not yet support Firestore document reference values or geo points.');
+      ' Local testing does not yet support Firestore geo points.');
   };
 
   return mapValues(data, encodeHelper);


### PR DESCRIPTION
Closes #24

This PR is to add serialisation support for `firestore.Timestamp` and `DocumentReference` for use in `makeDocumentSnapshot`.

This fills in the gaps of functionality for the following:
- Online tests can now be written for Firestore functions  that need to receive a `DocumentReference` as part of the `DocumentSnapshot`
- `firestore.Timestamp` can now be used instead of just `Date`. This is very useful when defining interfaces and models in TS where setting a timestamp had to use `Date`, but when getting the timestamp from the database would be `firestore.Timestamp`;

Tests are passing however I haven't added any new tests; There's currently no coverage for this part of the package.