### PR TITLE
Improvement for DataSnapshot paths (#10, #26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
     "chai": "^4.1.2",
-    "firebase-admin": "~6.1.0",
+    "firebase-admin": "^6.2.0",
     "firebase-functions": "^2.1.0",
     "mocha": "^5.0.5",
     "sinon": "^4.4.9",
     "tslint": "^5.8.0",
-    "typescript": "^2.4.1"
+    "typescript": "^2.9.2"
   },
   "peerDependencies": {
     "firebase-functions": ">1.0.1",

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -116,7 +116,7 @@ describe('main', () => {
       expect(context.resource.name).to.equal('ref/a/nested/b');
     });
 
-    it('should throw when snapshot path includes unspecified wildcards', () => {
+    it('should throw when snapshot path includes wildcards', () => {
       const fft = new FirebaseFunctionsTest();
       fft.init();
 
@@ -141,9 +141,8 @@ describe('main', () => {
         '/ref/cat/nested/that',
       );
 
-      const params = {};
       const wrapped = wrap(constructCF('google.firebase.database.ref.write'));
-      const result = wrapped(snap, { params });
+      const result = wrapped(snap, {});
 
       expect(result.data._path).to.equal('ref/cat/nested/that');
       expect(result.data.key).to.equal('that');
@@ -151,18 +150,14 @@ describe('main', () => {
       expect(result.context.resource.name).to.equal('ref/cat/nested/that');
     });
 
-    it('should error when DataSnapshot wildcard path does not match resource path', () => {
+    it('should error when DataSnapshot path does not match trigger template', () => {
       const fft = new FirebaseFunctionsTest();
       fft.init();
 
       const snap = makeDataSnapshot(
           'hello world',
-          '/different/{wildcard}/nested/{anotherWildcard}',
+          '/different/at/nested/bat',
       );
-      const params = {
-          wildcard: 'at',
-          anotherWildcard: 'bat',
-      };
       const wrapped = wrap(constructCF('google.firebase.database.ref.write'));
       expect(() => wrapped(snap, { params })).to.throw();
     });
@@ -176,7 +171,7 @@ describe('main', () => {
       expect(params).to.deep.equal({company: 'firebase', user: 'abe'});
     });
 
-    it('should not match unfilled wildcards which is too long', () => {
+    it('should not match unfilled wildcards', () => {
       const params = _extractParamsFromPath(
           'companies/{company}/users/{user}',
           'companies/{still_wild}/users/abe');

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -116,6 +116,7 @@ describe('main', () => {
       const wrapped = wrap(constructCF('google.firebase.database.ref.write'));
       const result = wrapped(snap, { params });
       expect(result.data._path).to.equal('ref/at/nested/bat');
+      expect(result.data.key).to.equal('bat');
       expect(result.context.resource.name).to.equal('ref/at/nested/bat');
     });
 

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -161,6 +161,7 @@ describe('main', () => {
 
       expect(result.data._path).to.equal('ref/cat/nested/that');
       expect(result.data.key).to.equal('that');
+      expect(result.context.params.wildcard).to.equal('cat');
       expect(result.context.resource.name).to.equal('ref/cat/nested/that');
     });
 
@@ -179,6 +180,8 @@ describe('main', () => {
 
       expect(result.data._path).to.equal('ref/cat/nested/where');
       expect(result.data.key).to.equal('where');
+      expect(result.context.params.wildcard).to.equal('cat');
+      expect(result.context.params.anotherWildcard).to.equal('where');
       expect(result.context.resource.name).to.equal('ref/cat/nested/where');
     });
 

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -127,25 +127,6 @@ describe('main', () => {
       expect(result.context.resource.name).to.equal('ref/at/nested/bat');
     });
 
-    it('should set auto-fill DataSnapshot path based on params', () => {
-      const fft = new FirebaseFunctionsTest();
-      fft.init();
-
-      const snap = makeDataSnapshot(
-          'hello world',
-          '/ref/{wildcard}/nested/{anotherWildcard}',
-      );
-      const params = {
-          wildcard: 'at',
-          anotherWildcard: 'bat',
-      };
-      const wrapped = wrap(constructCF('google.firebase.database.ref.write'));
-      const result = wrapped(snap, { params });
-      expect(result.data._path).to.equal('ref/at/nested/bat');
-      expect(result.data.key).to.equal('bat');
-      expect(result.context.resource.name).to.equal('ref/at/nested/bat');
-    });
-
     it('should set auto-fill params based on DataSnapshot path', () => {
       const fft = new FirebaseFunctionsTest();
       fft.init();

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -108,7 +108,7 @@ describe('main', () => {
       expect(context.resource.name).to.equal('ref/a/nested/b');
     });
 
-    it('should set auto-fill DataSnapshot path based on params', () => {
+    it('should throw when snapshot path includes unspecified wildcards', () => {
       const fft = new FirebaseFunctionsTest();
       fft.init();
 
@@ -121,10 +121,7 @@ describe('main', () => {
           anotherWildcard: 'bat',
       };
       const wrapped = wrap(constructCF('google.firebase.database.ref.write'));
-      const result = wrapped(snap, { params });
-      expect(result.data._path).to.equal('ref/at/nested/bat');
-      expect(result.data.key).to.equal('bat');
-      expect(result.context.resource.name).to.equal('ref/at/nested/bat');
+      expect(() => wrapped(snap, { params })).to.throw();
     });
 
     it('should set auto-fill params based on DataSnapshot path', () => {
@@ -144,26 +141,6 @@ describe('main', () => {
       expect(result.data.key).to.equal('that');
       expect(result.context.params.wildcard).to.equal('cat');
       expect(result.context.resource.name).to.equal('ref/cat/nested/that');
-    });
-
-    it('should allow mixed wildcards based on DataSnapshot path and params', () => {
-      const fft = new FirebaseFunctionsTest();
-      fft.init();
-
-      const snap = makeDataSnapshot(
-          'hello world',
-          '/ref/cat/nested/{anotherWildcard}',
-      );
-
-      const params = {anotherWildcard: 'where'};
-      const wrapped = wrap(constructCF('google.firebase.database.ref.write'));
-      const result = wrapped(snap, { params });
-
-      expect(result.data._path).to.equal('ref/cat/nested/where');
-      expect(result.data.key).to.equal('where');
-      expect(result.context.params.wildcard).to.equal('cat');
-      expect(result.context.params.anotherWildcard).to.equal('where');
-      expect(result.context.resource.name).to.equal('ref/cat/nested/where');
     });
 
     it('should error when DataSnapshot wildcard path does not match resource path', () => {

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -30,7 +30,7 @@ export function makeDataSnapshot(
   /** Value of data for the snapshot. */
   val: string | number | boolean | any[] | object,
   /** Full path of the reference (e.g. 'users/alovelace'). */
-  refPath: string,
+  refPath?: string,
   /** The Firebase app that the database belongs to.
    * The databaseURL supplied when initializing the app will be used for creating this snapshot.
    * You do not need to supply this parameter if you supplied Firebase config values when initializing


### PR DESCRIPTION
### Description
Fixes common UX issue where context.params are not populated from wildcards in path. (See #10 and #26)
 
### Code sample

#### New Behavior
```js
const func = functions.database
  .ref("/different/{wildcard}/nested/{anotherWildcard}")
  .onCreate((snap, context) => {
    console.log(context.params.wildcard == "at") // true
    console.log(context.params.anotherWildcard == "bat") // true
    console.log(snap.key == "bat") // true
  }

const snap = makeDataSnapshot(
    'hello world',
    '/different/at/nested/bat',
);
const params = {};
wrap(func)(snap, {params});
```

#### New Behavior
```js
const func = functions.database
  .ref("/different/{wildcard}/nested/{anotherWildcard}")
  .onCreate((snap, context) => {
    console.log(context.params.wildcard == "at") // true
    console.log(context.params.anotherWildcard == "bat") // true
    console.log(snap.key == "bat") // true
  }

const snap = makeDataSnapshot(
    'hello world',
    '/different/at/nested/bat',
);
const params = {wildcard: "that"};
wrap(func)(snap, {params}); // Throws error due to overlapping "wildcard" definition
```
I've also added some better logic for ensuring a DataSnapshot's path fits the trigger it is passed to.

#### Previous / Current Behavior (DataSnapshot Path Checking)
```js
const func = functions.database
  .ref("/good_path/{id}")
  .onCreate(snap => {
    console.log(snap.ref.path == "/bad_path/test") // true, previously silently wrong
  }

const snap = makeDataSnapshot(
    'hello world',
    '/bad_path/{id}', // Note mismatch with trigger ref
);
const params = {
    id: "test"
};
wrap(func)(snap, {params}); // New functionality throws an error on invocation due to mismatch between snap and trigger.
```

### Tests
Added various tests for new functionality which changes DataSnapshot `path`, `_isValidWildcardMatch`, and `_extractParamsFromPath`.

All test pass, [canonical uppercase sample tests](https://github.com/firebase/functions-samples/tree/master/quickstarts/uppercase/functions/test) also pass without change.
