### PR TITLE
Changes "makeObjectMetadata" to default to FIREBASE_CONFIG bucket if bucket not provided. (#19)

### DIFF
--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -27,10 +27,11 @@ export function makeObjectMetadata(
   /** Fields of ObjectMetadata that you'd like to specify. */
   fields: { [key: string]: string },
 ): storage.ObjectMetadata {
+  const configBucket = JSON.parse(process.env.FIREBASE_CONFIG || '{}').storageBucket;
   const template = {
     kind: 'storage#object',
     id: '',
-    bucket: '',
+    bucket: configBucket || '',
     timeCreated: '',
     updated: '',
     storageClass: 'STANDARD',


### PR DESCRIPTION
### Description

Addresses #19, changes default bucket so you don't need to supply it on every `makeObjectMetadata` call.

### Code sample
#### Previous
```js
const fft = require("firebase-functions-test")({
  // ...
  storageBucket: "my-firebase-project-id.appspot.com"
});
fft.storage.makeObjectMetadata({
      name: 'unit_tests/Amaze.png',
      bucket: 'my-firebase-project-id.appspot.com',
      contentType: 'image/png'
});
```

#### New
```js
const fft = require("firebase-functions-test")({
  // ...
  storageBucket: "my-firebase-project-id.appspot.com"
});
fft.storage.makeObjectMetadata({
      name: 'unit_tests/Amaze.png',
      contentType: 'image/png'
});
```

