### PR TITLE
Adds `onCall` function support (#9)

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -62,6 +62,7 @@ describe('index', () => {
 import './lifecycle.spec';
 import './main.spec';
 import './app.spec';
+import './providers/https.spec';
 // import './providers/analytics.spec';
 // import './providers/auth.spec';
 // import './providers/database.spec';

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -88,6 +88,15 @@ describe('main', () => {
       expect(context.authType).to.equal('USER');
     });
 
+    it('should allow allow invalid options', () => {
+      const wrapped = wrap(constructCF());
+      expect(() => wrapped('data', {
+          auth: { uid: 'abc' },
+          authType: 'USER',
+          isInvalid: true,
+      } as any)).to.throw();
+    });
+
     it('should generate the appropriate resource based on params', () => {
       const params = {
         wildcard: 'a',

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -88,11 +88,10 @@ describe('main', () => {
       expect(context.authType).to.equal('USER');
     });
 
-    it('should allow allow invalid options', () => {
+    it('should throw when passed invalid options', () => {
       const wrapped = wrap(constructCF());
       expect(() => wrapped('data', {
           auth: { uid: 'abc' },
-          authType: 'USER',
           isInvalid: true,
       } as any)).to.throw();
     });

--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import * as functions from 'firebase-functions';
+import fft = require('../../src/index');
+
+const cfToUpperCaseOnRequest = functions.https.onRequest((req, res) => {
+    res.json({msg: req.params.message.toUpperCase()});
+});
+
+const cfToUpperCaseOnCall = functions.https.onCall((data, context) => {
+    return {msg: data.message.toUpperCase()};
+});
+
+describe('providers/https', () => {
+    describe('#wrap', () => {
+        it('should not throw when passed onRequest function', async () => {
+            const test = fft();
+            /*
+                Note that we must cast the function to any here because onRequst functions
+                do not fulfill Runnable<>, so these checks are solely for usage of this lib
+                in JavaScript test suites.
+             */
+            expect(() => test.wrap(cfToUpperCaseOnRequest as any)).to.throw();
+        });
+
+        it('should run the wrapped onCall function and return result', async () => {
+            const test = fft();
+            const result = await test.wrap(cfToUpperCaseOnCall)({message: 'lowercase'});
+            expect(result).to.deep.equal({msg: 'LOWERCASE'});
+        });
+    });
+});

--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -7,25 +7,39 @@ const cfToUpperCaseOnRequest = functions.https.onRequest((req, res) => {
 });
 
 const cfToUpperCaseOnCall = functions.https.onCall((data, context) => {
-    return {msg: data.message.toUpperCase()};
+    const result = {
+        msg: data.message.toUpperCase(),
+        from: 'anonymous',
+    };
+
+    if (context.auth && context.auth.uid) {
+        result.from = context.auth.uid;
+    }
+
+    return result;
 });
 
 describe('providers/https', () => {
-    describe('#wrap', () => {
-        it('should not throw when passed onRequest function', async () => {
-            const test = fft();
-            /*
-                Note that we must cast the function to any here because onRequst functions
-                do not fulfill Runnable<>, so these checks are solely for usage of this lib
-                in JavaScript test suites.
-             */
-            expect(() => test.wrap(cfToUpperCaseOnRequest as any)).to.throw();
-        });
+    it('should not throw when passed onRequest function', async () => {
+        const test = fft();
+        /*
+            Note that we must cast the function to any here because onRequst functions
+            do not fulfill Runnable<>, so these checks are solely for usage of this lib
+            in JavaScript test suites.
+         */
+        expect(() => test.wrap(cfToUpperCaseOnRequest as any)).to.throw();
+    });
 
-        it('should run the wrapped onCall function and return result', async () => {
-            const test = fft();
-            const result = await test.wrap(cfToUpperCaseOnCall)({message: 'lowercase'});
-            expect(result).to.deep.equal({msg: 'LOWERCASE'});
-        });
+    it('should run the wrapped onCall function and return result', async () => {
+        const test = fft();
+        const result = await test.wrap(cfToUpperCaseOnCall)({message: 'lowercase'});
+        expect(result).to.deep.equal({msg: 'LOWERCASE', from: 'anonymous'});
+    });
+
+    it('should accept auth params', async () => {
+        const test = fft();
+        const options = {auth: {uid: 'abc'}};
+        const result = await test.wrap(cfToUpperCaseOnCall)({message: 'lowercase'}, options);
+        expect(result).to.deep.equal({msg: 'LOWERCASE', from: 'abc'});
     });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ export type EventContextOptions = {
    *  the function. Defaults to null.
    */
   auth?: any;
-  /** (Only for database and functions.) The authentication state of the user that triggered the function.
+  /** (Only for database and https.onCall functions.) The authentication state of the user that triggered the function.
    * Default is 'UNAUTHENTICATED'.
    */
   authType?: 'ADMIN' | 'USER' | 'UNAUTHENTICATED';


### PR DESCRIPTION
### Description

Adds support for `https.onCall` functions and improves filtering of `https.onRequest` functions.

**Do not merge!** I'm not sure if there are other aspects of this I'm missing. I'm not sure if there's any value to adding `providers/https.ts` other than to allow `onCall` support to be discoverable in the library. Since the bundles passed to the functions are arbitrary JSON I'm not sure what help we could be.

Let me know your thoughts!

### Code sample

See [providers/https.spec.ts](https://github.com/firebase/firebase-functions-test/blob/ah-oncall/spec/providers/https.spec.ts)
