### PR TITLE
fix(wrap): Extensions `functions.handler` -> `eventType` key exists but is `undefined` value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '6.14.0'
 - '8'
+- '10'
 - stable
 sudo: false

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "lodash": "^4.17.5"
   },
   "devDependencies": {
-    "@types/chai": "~4.1.2",
-    "@types/mocha": "^5.0.0",
-    "chai": "^4.1.2",
-    "firebase-admin": "~6.1.0",
-    "firebase-functions": "^2.1.0",
-    "mocha": "^5.0.5",
-    "sinon": "^4.4.9",
-    "tslint": "^5.8.0",
-    "typescript": "^2.4.1"
+    "@types/chai": "~4.2.4",
+    "@types/mocha": "^5.2.7",
+    "chai": "^4.2.0",
+    "firebase-admin": "~8.6.1",
+    "firebase-functions": "^3.3.0",
+    "mocha": "^6.2.2",
+    "sinon": "^7.5.0",
+    "tslint": "^5.20.0",
+    "typescript": "^3.6.4"
   },
   "peerDependencies": {
     "firebase-functions": ">1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.5"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.2",
+    "@types/chai": "~4.1.2",
     "@types/mocha": "^5.0.0",
     "chai": "^4.1.2",
     "firebase-admin": "~6.1.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ export function wrap<T>(cloudFunction: CloudFunction<T>): WrappedFunction {
           params: {},
       };
 
-      if (has(defaultContext, 'eventType') &&
+      if (has(defaultContext, 'eventType') && defaultContext.eventType != undefined &&
         defaultContext.eventType.match(/firebase.database/)) {
         defaultContext.authType = 'UNAUTHENTICATED';
         defaultContext.auth = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ export function wrap<T>(cloudFunction: CloudFunction<T>): WrappedFunction {
           params: {},
       };
 
-      if (has(defaultContext, 'eventType') && defaultContext.eventType != undefined &&
+      if (has(defaultContext, 'eventType') && defaultContext.eventType !== undefined &&
         defaultContext.eventType.match(/firebase.database/)) {
         defaultContext.authType = 'UNAUTHENTICATED';
         defaultContext.auth = null;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

I've been working on adding tests to [firebase/extensions](https://github.com/firebase/extensions) and when trying to wrap the function handlers used by Extensions (e.g. `functions.handler.firestore.document.onWrite`) it errors with `TypeError: Cannot read property 'match' of undefined` as the `eventType` key 'does' exist on the `defaultContext` object, but has an `undefined` value assigned.

This small PR adds an additional `undefined` check.

```js
export const fstranslate = functions.handler.firestore.document.onWrite(
  async (change): Promise<void> => {
  console.warn('Hello from inside my wrapped handler function.');
  return;
});

// ...
import * as functionsTestInit from "firebase-functions-test";
// ...
let functionsTest = functionsTestInit();
// ...


const wrappedFn = functionsTest.wrap(exportedFns.fstranslate);
const before = functionsTest.firestore.makeDocumentSnapshot({}, "foo/id1");
const after = functionsTest.firestore.makeDocumentSnapshot({ input: "hello" }, "foo/id1");
const change = functionsTest.makeChange(before, after);

wrappedFn(change); // Errors
```


**Before**:
![image](https://user-images.githubusercontent.com/5347038/67393764-e9ee7b80-f59a-11e9-85a5-e1048739367a.png)

**After**:
![image](https://user-images.githubusercontent.com/5347038/67394077-8153ce80-f59b-11e9-8efe-33bd8d4af25f.png)


### Code sample

N/A

----

cc @laurenzlong @karayu 