### PR TITLE
Support for scheduled functions

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -72,6 +72,7 @@ import './app.spec';
 import './providers/https.spec';
 import './providers/firestore.spec';
 import './providers/database.spec';
+import './providers/scheduled.spec';
 // import './providers/analytics.spec';
 // import './providers/auth.spec';
 // import './providers/https.spec';

--- a/spec/providers/scheduled.spec.ts
+++ b/spec/providers/scheduled.spec.ts
@@ -1,0 +1,51 @@
+import * as sinon from 'sinon';
+import * as functions from 'firebase-functions';
+import fft = require('../../src/index');
+import { WrappedScheduledFunction } from '../../src/main';
+
+describe('providers/scheduled', () => {
+  const fakeFn = sinon.fake.resolves();
+  const scheduledFunc = functions.pubsub
+    .schedule('every 2 hours')
+    .onRun(fakeFn);
+
+  const emptyObjectMatcher = sinon.match(
+    (v) => sinon.match.object.test(v) && Object.keys(v).length === 0
+  );
+
+  afterEach(() => {
+    fakeFn.resetHistory();
+  });
+
+  it('should run the wrapped function with generated context', async () => {
+    const test = fft();
+    const fn: WrappedScheduledFunction = test.wrap(scheduledFunc);
+    await fn();
+    // Function should only be called with 1 argument
+    sinon.assert.calledOnce(fakeFn);
+    sinon.assert.calledWithExactly(
+      fakeFn,
+      sinon.match({
+        eventType: sinon.match.string,
+        timestamp: sinon.match.string,
+        params: emptyObjectMatcher,
+      })
+    );
+  });
+
+  it('should run the wrapped function with provided context', async () => {
+    const timestamp = new Date().toISOString();
+    const test = fft();
+    const fn: WrappedScheduledFunction = test.wrap(scheduledFunc);
+    await fn({ timestamp });
+    sinon.assert.calledOnce(fakeFn);
+    sinon.assert.calledWithExactly(
+      fakeFn,
+      sinon.match({
+        eventType: sinon.match.string,
+        timestamp,
+        params: emptyObjectMatcher,
+      })
+    );
+  });
+});


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

Adds support for scheduled functions that use only the `context` parameter when called.

Also includes tests.

### Code sample

```
const scheduledFunc = functions.pubsub.schedule('every 2 hours').onRun(async context => {
 // Do something
});

require('firebase-functions-test').wrap(scheduledFunc)();

// Or with a context
require('firebase-functions-test').wrap(scheduledFunc)({ timestamp });
```
