### PR TITLE
feat: `wrap` method now accepts `resource` as override in Context object.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -138,7 +138,7 @@ export function wrap<T>(
       };
     } else {
       _checkOptionValidity(
-        ['eventId', 'timestamp', 'params', 'auth', 'authType'],
+        ['eventId', 'timestamp', 'params', 'auth', 'authType', 'resource'],
         options
       );
       const defaultContext = _makeDefaultContext(cloudFunction, options);

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,18 @@ export type EventContextOptions = {
    * Default is 'UNAUTHENTICATED'.
    */
   authType?: 'ADMIN' | 'USER' | 'UNAUTHENTICATED';
+
+  /** Resource is a standard format for defining a resource (google.rpc.context.AttributeContext.Resource).
+   * In Cloud Functions, it is the resource that triggered the function - such as a storage bucket.
+   */
+  resource?: {
+    service: string;
+    name: string;
+    type?: string;
+    labels?: {
+      [tag: string]: string;
+    };
+  };
 };
 
 /** Fields of the callable context that can be overridden/customized. */


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

As part of trying to test the extensions/firestore-bigquery-export module. We need to introduce the ability to set the resource key values (the types already support this, just this change is missing). Specifically, [this line](https://github.com/firebase/extensions/blob/next/firestore-bigquery-export/functions/src/index.ts#L45) will fail when using the function wrap helper with `cannot read property 'name' of undefined`. This change allows us to specify the resource values needed for the wrapped cloud function trigger.


### Code sample

```ts
const wrapped = functionsTest.wrap(require("../src/index").fsexportbigquery);
wrapped(docChange, {
  eventId: "test",
  resource: {
    name: "test",
  },
});
```
