### PR TITLE
Cleanup config after test run

### DIFF
--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -134,8 +134,9 @@ describe('main', () => {
   });
 
   describe('#mockConfig', () => {
-    after(() => {
+    afterEach(() => {
       delete process.env.CLOUD_RUNTIME_CONFIG;
+      delete functions.config.singleton;
     });
 
     it('should mock functions.config()', () => {

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -143,5 +143,11 @@ describe('main', () => {
       mockConfig(config);
       expect(functions.config()).to.deep.equal(config);
     });
+
+    it('should allow multiple mock configurations', () => {
+      const config = { baz: { qux: 'quxx ' } };
+      mockConfig(config);
+      expect(functions.config()).to.deep.equal(config);
+    });
   });
 });


### PR DESCRIPTION
### Description

I need to change the firebase functions configuration sometimes while testing and there is no clear documentation on how to do that. I've added a test case that fails when changing the functions config between test runs, and a fix to the test configuration fix the test.

However, I am not sure if that is the way it should be done. I was surprised that the cleanup function didn't do this and thought about adding this step to that. However the cleanup function doesn't have anything to do with functions config right now so I wasn't sure if that was desirable. If that is the way this should be done then I would be happy to modify this pull request to do that.

### Details

firebase-functions [only inits the config one time](https://github.com/firebase/firebase-functions/blob/2940a4b5230e6469ebca3102b11d45915a3a8939/src/config.ts#L26), and otherwise uses a singleton object. So just deleting the `process.env.CLOUD_RUNTIME_CONFIG` during test runs is insufficient. You must also delete the `functions.config.singleton` object.