### PR TITLE
Allow RTDB instance to be specified when using makeDataSnapshot

### DIFF
--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -32,4 +32,25 @@ describe('providers/database', () => {
     expect(snapshot.val()).to.deep.equal(null);
     expect(snapshot.ref.key).to.equal('path');
   });
+
+  it('should use the default test apps databaseURL if no instance is specified in makeDataSnapshot', async () => {
+    const snapshot = makeDataSnapshot(null, 'path', null);
+
+    expect(snapshot.ref.toString()).to.equal(
+      'https://not-a-project.firebaseio.com/path'
+    );
+  });
+
+  it('should allow different DB instance to be specified in makeDataSnapshot', async () => {
+    const snapshot = makeDataSnapshot(
+      null,
+      'path',
+      null,
+      'https://another-instance.firebaseio.com'
+    );
+
+    expect(snapshot.ref.toString()).to.equal(
+      'https://another-instance.firebaseio.com/path'
+    );
+  });
 });

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -36,12 +36,18 @@ export function makeDataSnapshot(
    * You do not need to supply this parameter if you supplied Firebase config values when initializing
    * firebase-functions-test.
    */
-  firebaseApp?: app.App
+  firebaseApp?: app.App,
+  /**
+   * The RTDB instance to use when creating snapshot. This will override the `firebaseApp` parameter.
+   * If omitted the default RTDB instance is used.
+   */
+  instance?: string
 ): database.DataSnapshot {
   return new database.DataSnapshot(
     val,
     refPath,
-    firebaseApp || testApp().getApp()
+    firebaseApp || testApp().getApp(),
+    instance
   );
 }
 


### PR DESCRIPTION
### Description

Allow creation of `DataSnapshot`s for multiple RTDB instances.

#### Why

Currently the only way to create a `DataSnapshot` for different RTDB instances is to create a `App` per instance.

### Code sample

```js
const snapshot = makeDataSnapshot({ hello: 'world' }, 'path', null, 'https://another-instance.firebaseio.com');
```
