### PR TITLE
added method to clear all firestore data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 .vscode
 *.tgz
 .tmp
+*.log

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "pretest": "node_modules/.bin/tsc",
     "test": "mocha .tmp/spec/index.spec.js",
     "posttest": "npm run lint && rm -rf .tmp",
+    "preintegrationTest": "node_modules/.bin/tsc",
+    "integrationTest": "firebase emulators:exec --project=not-a-project --only firestore 'mocha .tmp/spec/integration/**/*.spec.js'",
+    "postintegrationTest": "rm -rf .tmp",
     "format": "prettier --check '**/*.{json,ts,yml,yaml}'",
     "format:fix": "prettier --write '**/*.{json,ts,yml,yaml}'"
   },
@@ -44,6 +47,7 @@
     "chai": "^4.2.0",
     "firebase-admin": "~8.9.0",
     "firebase-functions": "^3.3.0",
+    "firebase-tools": "^8.9.2",
     "mocha": "^6.2.2",
     "prettier": "^1.19.1",
     "sinon": "^7.5.0",

--- a/spec/integration/providers/firestore.spec.ts
+++ b/spec/integration/providers/firestore.spec.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { firestore, initializeApp } from 'firebase-admin';
+import fft = require('../../../src/index');
+
+before(() => {
+  initializeApp();
+});
+
+describe('providers/firestore', () => {
+  it('clears database with clearFirestoreData', async () => {
+    const test = fft({ projectId: 'not-a-project' });
+    const db = firestore();
+
+    await Promise.all([
+      db
+        .collection('test')
+        .doc('doc1')
+        .set({}),
+      db
+        .collection('test')
+        .doc('doc1')
+        .collection('test')
+        .doc('doc2')
+        .set({}),
+    ]);
+
+    await test.firestore.clearFirestoreData({ projectId: 'not-a-project' });
+
+    const docs = await Promise.all([
+      db
+        .collection('test')
+        .doc('doc1')
+        .get(),
+      db
+        .collection('test')
+        .doc('doc1')
+        .collection('test')
+        .doc('doc2')
+        .get(),
+    ]);
+    expect(docs[0].exists).to.be.false;
+    expect(docs[1].exists).to.be.false;
+  });
+});

--- a/spec/integration/providers/firestore.spec.ts
+++ b/spec/integration/providers/firestore.spec.ts
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { firestore, initializeApp } from 'firebase-admin';
 import fft = require('../../../src/index');
 
-before(() => {
-  initializeApp();
-});
-
 describe('providers/firestore', () => {
+  before(() => {
+    initializeApp();
+  });
+
   it('clears database with clearFirestoreData', async () => {
     const test = fft({ projectId: 'not-a-project' });
     const db = firestore();

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -228,22 +228,25 @@ const FIRESTORE_ADDRESS = FIRESTORE_ADDRESS_ENVS.reduce(
 );
 const FIRESTORE_PORT = FIRESTORE_ADDRESS.split(':')[1];
 
-export type ClearFirestoreDataOptions = {
-  projectId: string;
-};
-
 /** Clears all data in firestore. Works only in offline mode.
  */
-export function clearFirestoreData(options: ClearFirestoreDataOptions) {
+export function clearFirestoreData(options: { projectId: string } | string) {
   return new Promise((resolve, reject) => {
-    if (!options.projectId) {
+    let projectId;
+
+    if (typeof options === 'string') {
+      projectId = options;
+    } else if (typeof options === 'object' && has(options, 'projectId')) {
+      projectId = options.projectId;
+    } else {
       throw new Error('projectId not specified');
     }
+    
     const config = {
       method: 'DELETE',
       hostname: 'localhost',
       port: FIRESTORE_PORT,
-      path: `/emulator/v1/projects/${options.projectId}/databases/(default)/documents`,
+      path: `/emulator/v1/projects/${projectId}/databases/(default)/documents`,
     };
 
     const req = http.request(config, (res) => {
@@ -259,7 +262,7 @@ export function clearFirestoreData(options: ClearFirestoreDataOptions) {
     });
 
     const postData = JSON.stringify({
-      database: `projects/${options.projectId}/databases/(default)`,
+      database: `projects/${projectId}/databases/(default)`,
     });
 
     req.setHeader('Content-Length', postData.length);

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -236,6 +236,9 @@ export type ClearFirestoreDataOptions = {
  */
 export function clearFirestoreData(options: ClearFirestoreDataOptions) {
   return new Promise((resolve, reject) => {
+    if (!options.projectId) {
+      throw new Error('projectId not specified');
+    }
     const config = {
       method: 'DELETE',
       hostname: 'localhost',

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -241,7 +241,7 @@ export function clearFirestoreData(options: { projectId: string } | string) {
     } else {
       throw new Error('projectId not specified');
     }
-    
+
     const config = {
       method: 'DELETE',
       hostname: 'localhost',


### PR DESCRIPTION
### Description

Added a function to clear all firestore data between tests. Similar to https://github.com/firebase/firebase-js-sdk/blob/master/packages/testing/src/api/index.ts#L233

This makes it easier to run tests in offline mode

### Code sample

```js
const test = require("firebase-functions-test")({
	projectId: "project-id",
});

describe('test', () => {
	afterEach(async () => {
		await test.firestore.clearFirestoreData({ projectId: "project-id" });
	});
	it('test1', () => {
		// test that involes database changes
	});
	
	it('test2', () => {
		// test that involes database changes
	});
});
```

in order to implement tests I think I would need change:
`"test": "mocha .tmp/spec/index.spec.js"` 
to
`"test": "firebase emulators:exec 'mocha .tmp/spec/index.spec.js'"`

I want to know if there is a better way to implement tests before I started.