### PR TITLE
Adds changelog for 0.2.2 and correct package.json version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-- Adds `clearFirestoreData` to clear all Firestore data in the Firestore emulator.
-- Adds ability to create DataSnapshots for multiple RTDB instances.
+- Adds `clearFirestoreData` to clear all Firestore data in the Firestore emulator (#71).
+- Adds ability to create DataSnapshots for multiple RTDB instances (#72).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-
+- Adds `clearFirestoreData` to clear all Firestore data in the Firestore emulator.
+- Adds ability to create DataSnapshots for multiple RTDB instances.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-functions-test",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A testing companion to firebase-functions.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Looks like we had something go wrong with a merge at some point - v0.2.1 has already been released, but package.json still showed 0.2.0.