### PR TITLE
Remove functions.config.singleton

### DIFF
--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -134,14 +134,33 @@ describe('main', () => {
   });
 
   describe('#mockConfig', () => {
-    after(() => {
+    let config: Record<string, unknown>;
+
+    beforeEach(() => {
+      config = { foo: { bar: 'faz ' } };
+    });
+
+    afterEach(() => {
       delete process.env.CLOUD_RUNTIME_CONFIG;
     });
 
     it('should mock functions.config()', () => {
-      const config = { foo: { bar: 'faz ' } };
       mockConfig(config);
       expect(functions.config()).to.deep.equal(config);
+    });
+
+    it('should purge singleton config object when it is present', () => {
+      mockConfig(config);
+      config.foo = { baz: 'qux' };
+      mockConfig(config);
+
+      expect(functions.config()).to.deep.equal(config);
+    });
+
+    it('should not throw an error when functions.config.singleton is missing', () => {
+      delete functions.config.singleton;
+
+      expect(() => mockConfig(config)).to.not.throw(Error);
     });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@
 
 import { has, merge, random, get } from 'lodash';
 
-import { CloudFunction, EventContext, Change, https } from 'firebase-functions';
+import { CloudFunction, EventContext, Change, https, config } from 'firebase-functions';
 
 /** Fields of the event context that can be overridden/customized. */
 export type EventContextOptions = {
@@ -237,6 +237,10 @@ export function makeChange<T>(before: T, after: T): Change<T> {
 }
 
 /** Mock values returned by `functions.config()`. */
-export function mockConfig(config: { [key: string]: { [key: string]: any } }) {
-  process.env.CLOUD_RUNTIME_CONFIG = JSON.stringify(config);
+export function mockConfig(conf: { [key: string]: { [key: string]: any } }) {
+  if (config.singleton) {
+    delete config.singleton;
+  }
+
+  process.env.CLOUD_RUNTIME_CONFIG = JSON.stringify(conf);
 }


### PR DESCRIPTION
**Description**

`functions.config()` parses ENV variable(s) only once and saves the value into a variable for later usage. Thus setting a new value to `process.env.CLOUD_RUNTIME_CONFIG` is not causing getting a recent value.

**Motivation**
Calling the `mockConfig` function multiple times with different configuration values makes writing unit tests easier and gives flexibility to the developer. What do you think?

P.S This topic has been already mentioned in #68.

**Code Sample**
```typescript
// spec/unit/auth-on-create.spec.ts
import test from 'firebase-functions-test';
const app = test();

describe('[Unit] Auth.onCreate()', () => {
  afterEach(() => {
    app.cleanup();
  });
  
  it('does something with config().foo', () => {
    app.mockConfig({ foo: 'bar' });
    ...
  });

  it('does something with config().baz', () => {
    app.mockConfig({ baz: 'qux' });
    ...
  });
});
```
