### PR TITLE
Firestore context params bind

### DIFF
--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -74,17 +74,6 @@ describe('main', () => {
       expect(context.timestamp).to.equal('2018-03-28T18:58:50.370Z');
     });
 
-    it('should create context params and resource from contextOptions on firestore event', async () => {
-      const params = {
-        wildcard: 'a',
-        anotherWildcard: 'b',
-      };
-      const wrapped = wrap(constructCF());
-      const context = wrapped('data', { params }).context;
-      expect(context.params).to.deep.equal(params);
-      expect(context.resource.name).to.equal('ref/a/nested/b');
-    });
-
     it('should generate auth and authType for database functions', () => {
       const context = wrap(constructCF('google.firebase.database.ref.write'))(
         'data'

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,6 +232,7 @@ function _makeDefaultContext<T>(
   data?: T
 ): EventContext {
   let eventContextOptions = options as EventContextOptions;
+  let isDocumentResourceName = false;
   const resource = cloudFunction.__trigger.eventTrigger && {
     service: cloudFunction.__trigger.eventTrigger.service,
     name: ''
@@ -239,6 +240,7 @@ function _makeDefaultContext<T>(
   if(cloudFunction.__trigger.eventTrigger.service == "firestore.googleapis.com" && !has(eventContextOptions, 'params')) {
     try {
       cloudFunction.__trigger.eventTrigger.resource.substring(0, cloudFunction.__trigger.eventTrigger.resource.indexOf("documents")) + "documents/" + (data as unknown as QueryDocumentSnapshot).ref.path;
+      isDocumentResourceName = true;
     } catch(error) {
       resource.name = _makeResourceName(cloudFunction.__trigger.eventTrigger.resource, has(eventContextOptions, 'params') && eventContextOptions.params);
     }
@@ -250,7 +252,7 @@ function _makeDefaultContext<T>(
     resource: resource,
     eventType: get(cloudFunction, '__trigger.eventTrigger.eventType'),
     timestamp: new Date().toISOString(),
-    params: _makeDefaultParams(cloudFunction.__trigger.eventTrigger.resource, resource.name),
+    params: isDocumentResourceName? _makeDefaultParams(cloudFunction.__trigger.eventTrigger.resource, resource.name) : {}
   };
   return defaultContext;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,9 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { has, merge, random, get } from 'lodash';
+import { has, merge, random, get, forEach, split, indexOf } from 'lodash';
 
 import { CloudFunction, EventContext, Change, https } from 'firebase-functions';
+import { QueryDocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
 
 /** Fields of the event context that can be overridden/customized. */
 export type EventContextOptions = {
@@ -153,7 +154,7 @@ export function wrap<T>(
         ['eventId', 'timestamp', 'params', 'auth', 'authType', 'resource'],
         options
       );
-      const defaultContext = _makeDefaultContext(cloudFunction, options);
+      const defaultContext = _makeDefaultContext(cloudFunction, options, data);
 
       if (
         has(defaultContext, 'eventType') &&
@@ -186,6 +187,21 @@ export function _makeResourceName(
   return resourceName;
 }
 
+function _makeDefaultParams(triggerResource, name) {
+  const wildcards = triggerResource.match(new RegExp('{[^/{}]*}', 'g'));
+  const params = {};
+  if (wildcards) {
+      const triggerResourceParts = split(triggerResource, '/');
+      const eventResourceParts = split(name, '/');
+      forEach(wildcards, (wildcard) => {
+          const wildcardNoBraces = wildcard.slice(1, -1);
+          const position = indexOf(triggerResourceParts, wildcard);
+          params[wildcardNoBraces] = eventResourceParts[position];
+      });
+  }
+  return params;
+}
+
 function _makeEventId(): string {
   return (
     Math.random()
@@ -212,21 +228,29 @@ function _checkOptionValidity(
 
 function _makeDefaultContext<T>(
   cloudFunction: CloudFunction<T>,
-  options: ContextOptions
+  options: ContextOptions,
+  data?: T
 ): EventContext {
   let eventContextOptions = options as EventContextOptions;
+  const resource = cloudFunction.__trigger.eventTrigger && {
+    service: cloudFunction.__trigger.eventTrigger.service,
+    name: ''
+  };
+  if(cloudFunction.__trigger.eventTrigger.service == "firestore.googleapis.com" && !has(eventContextOptions, 'params')) {
+    try {
+      cloudFunction.__trigger.eventTrigger.resource.substring(0, cloudFunction.__trigger.eventTrigger.resource.indexOf("documents")) + "documents/" + (data as unknown as QueryDocumentSnapshot).ref.path;
+    } catch(error) {
+      resource.name = _makeResourceName(cloudFunction.__trigger.eventTrigger.resource, has(eventContextOptions, 'params') && eventContextOptions.params);
+    }
+  } else {
+    resource.name = _makeResourceName(cloudFunction.__trigger.eventTrigger.resource, has(eventContextOptions, 'params') && eventContextOptions.params);
+  }
   const defaultContext: EventContext = {
     eventId: _makeEventId(),
-    resource: cloudFunction.__trigger.eventTrigger && {
-      service: cloudFunction.__trigger.eventTrigger.service,
-      name: _makeResourceName(
-        cloudFunction.__trigger.eventTrigger.resource,
-        has(eventContextOptions, 'params') && eventContextOptions.params
-      ),
-    },
+    resource: resource,
     eventType: get(cloudFunction, '__trigger.eventTrigger.eventType'),
     timestamp: new Date().toISOString(),
-    params: {},
+    params: _makeDefaultParams(cloudFunction.__trigger.eventTrigger.resource, resource.name),
   };
   return defaultContext;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -237,22 +237,30 @@ function _makeDefaultContext<T>(
     service: cloudFunction.__trigger.eventTrigger.service,
     name: ''
   };
-  if(cloudFunction.__trigger.eventTrigger.service == "firestore.googleapis.com" && !has(eventContextOptions, 'params')) {
+  if(cloudFunction.__trigger.eventTrigger.service === 'firestore.googleapis.com'
+  && !has(eventContextOptions, 'params')) {
     try {
-      cloudFunction.__trigger.eventTrigger.resource.substring(0, cloudFunction.__trigger.eventTrigger.resource.indexOf("documents")) + "documents/" + (data as unknown as QueryDocumentSnapshot).ref.path;
+      cloudFunction.__trigger.eventTrigger.resource.substring(0, cloudFunction.__trigger.eventTrigger.resource.indexOf('documents'))
+      + 'documents/'
+      + (data as unknown as QueryDocumentSnapshot).ref.path;
       isDocumentResourceName = true;
     } catch(error) {
-      resource.name = _makeResourceName(cloudFunction.__trigger.eventTrigger.resource, has(eventContextOptions, 'params') && eventContextOptions.params);
+      resource.name = _makeResourceName(cloudFunction.__trigger.eventTrigger.resource
+      , has(eventContextOptions, 'params')
+      && eventContextOptions.params);
     }
   } else {
-    resource.name = _makeResourceName(cloudFunction.__trigger.eventTrigger.resource, has(eventContextOptions, 'params') && eventContextOptions.params);
+    resource.name = _makeResourceName(cloudFunction.__trigger.eventTrigger.resource, has(eventContextOptions, 'params')
+    && eventContextOptions.params);
   }
   const defaultContext: EventContext = {
     eventId: _makeEventId(),
-    resource: resource,
+    resource,
     eventType: get(cloudFunction, '__trigger.eventTrigger.eventType'),
     timestamp: new Date().toISOString(),
-    params: isDocumentResourceName? _makeDefaultParams(cloudFunction.__trigger.eventTrigger.resource, resource.name) : {}
+    params: isDocumentResourceName
+    ? _makeDefaultParams(cloudFunction.__trigger.eventTrigger.resource, resource.name)
+    : {}
   };
   return defaultContext;
 }


### PR DESCRIPTION
While using the library to emulate a firestore document event, I noticed that I have to send the params separately.
This is a suggestion to bind the params from the DocumentSnapshot refPath property.

enable this usage:
```

const snap = test.firestore.makeDocumentSnapshot({}, 'wildcard/111/anotherwildcard/111');
      const wrapped = test.wrap(myFunctions.matchApartmentToUsers);
      return wrapped(snap).then(() => {});
```
instead of:
```
const snap = test.firestore.makeDocumentSnapshot({}, 'wildcard/111/anotherwildcard/111');
      const wrapped = test.wrap(myFunctions.matchApartmentToUsers);
      return wrapped(snap, {params:{wildcard:"111",anotherwildcard:"111"}}).then(() => {});
```
