### PR TITLE
Improve error message for Firestore encoding errors

### DIFF
--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -222,7 +222,7 @@ export function objectToValueProto(data: object) {
       'Cannot encode ' +
         val +
         'to a Firestore Value.' +
-        ' Local testing does not yet support Firestore geo points.'
+        ` Local testing does not yet support objects of type ${val?.constructor?.name}.`
     );
   };
 


### PR DESCRIPTION
Reviewing the geopoint bug I realized people complained that the error message called anything unserializeable a geopoint. This fixes that bug.