### PR TITLE
Failing test case for firebase/firebase-functions#926

### DIFF
--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -33,6 +33,14 @@ describe('providers/database', () => {
     expect(snapshot.ref.key).to.equal('path');
   });
 
+  it('should allow null child value in makeDataSnapshot', async () => {
+    const snapshot = makeDataSnapshot({ foo: null }, 'path');
+
+    expect(snapshot.exists()).be.false;
+    expect(snapshot.val()).to.deep.equal(null);
+    expect(snapshot.ref.key).to.equal('path');
+  });
+
   it('should use the default test apps databaseURL if no instance is specified in makeDataSnapshot', async () => {
     const snapshot = makeDataSnapshot(null, 'path', null);
 


### PR DESCRIPTION
### Description

See firebase/firebase-functions#926

Will be fixed once that is merged in and the [`firebase-function` dependency](https://github.com/bookcreator/firebase-functions-test/blob/3648691cb66b628bd9a87cbfe269444d4425300d/package.json#L49) updated.

### Code sample

[See test case](https://github.com/bookcreator/firebase-functions-test/blob/3648691cb66b628bd9a87cbfe269444d4425300d/spec/providers/database.spec.ts#L36-L42)

```js
  it('should allow null child value in makeDataSnapshot', async () => {
    const snapshot = makeDataSnapshot({ foo: null }, 'path');

    expect(snapshot.exists()).be.false;
    expect(snapshot.val()).to.deep.equal(null);
    expect(snapshot.ref.key).to.equal('path');
  });
 ```