### PR TITLE
Allow passing context.app to wrapped callable functions.

### DIFF
--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -28,89 +28,136 @@ import { mockConfig, makeChange, _makeResourceName, wrap } from '../src/main';
 
 describe('main', () => {
   describe('#wrap', () => {
-    const constructCF = (eventType?: string) => {
-      const cloudFunction = (input) => input;
-      set(cloudFunction, 'run', (data, context) => {
-        return { data, context };
-      });
-      set(cloudFunction, '__trigger', {
-        eventTrigger: {
-          resource: 'ref/{wildcard}/nested/{anotherWildcard}',
-          eventType: eventType || 'event',
-          service: 'service',
-        },
-      });
-      return cloudFunction as functions.CloudFunction<any>;
-    };
-
-    it('should invoke the function with the supplied data', () => {
-      const wrapped = wrap(constructCF());
-      expect(wrapped('data').data).to.equal('data');
-    });
-
-    it('should generate the appropriate context if no fields specified', () => {
-      const context = wrap(constructCF())('data').context;
-      expect(typeof context.eventId).to.equal('string');
-      expect(context.resource.service).to.equal('service');
-      expect(
-        /ref\/wildcard[1-9]\/nested\/anotherWildcard[1-9]/.test(
-          context.resource.name
-        )
-      ).to.be.true;
-      expect(context.eventType).to.equal('event');
-      expect(Date.parse(context.timestamp)).to.be.greaterThan(0);
-      expect(context.params).to.deep.equal({});
-      expect(context.auth).to.be.undefined;
-      expect(context.authType).to.be.undefined;
-    });
-
-    it('should allow specification of context fields', () => {
-      const wrapped = wrap(constructCF());
-      const context = wrapped('data', {
-        eventId: '111',
-        timestamp: '2018-03-28T18:58:50.370Z',
-      }).context;
-      expect(context.eventId).to.equal('111');
-      expect(context.timestamp).to.equal('2018-03-28T18:58:50.370Z');
-    });
-
-    it('should generate auth and authType for database functions', () => {
-      const context = wrap(constructCF('google.firebase.database.ref.write'))(
-        'data'
-      ).context;
-      expect(context.auth).to.equal(null);
-      expect(context.authType).to.equal('UNAUTHENTICATED');
-    });
-
-    it('should allow auth and authType to be specified for database functions', () => {
-      const wrapped = wrap(constructCF('google.firebase.database.ref.write'));
-      const context = wrapped('data', {
-        auth: { uid: 'abc' },
-        authType: 'USER',
-      }).context;
-      expect(context.auth).to.deep.equal({ uid: 'abc' });
-      expect(context.authType).to.equal('USER');
-    });
-
-    it('should throw when passed invalid options', () => {
-      const wrapped = wrap(constructCF());
-      expect(() =>
-        wrapped('data', {
-          auth: { uid: 'abc' },
-          isInvalid: true,
-        } as any)
-      ).to.throw();
-    });
-
-    it('should generate the appropriate resource based on params', () => {
-      const params = {
-        wildcard: 'a',
-        anotherWildcard: 'b',
+    describe('background functions', () => {
+      const constructBackgroundCF = (eventType?: string) => {
+        const cloudFunction = (input) => input;
+        set(cloudFunction, 'run', (data, context) => {
+          return { data, context };
+        });
+        set(cloudFunction, '__trigger', {
+          eventTrigger: {
+            resource: 'ref/{wildcard}/nested/{anotherWildcard}',
+            eventType: eventType || 'event',
+            service: 'service',
+          },
+        });
+        return cloudFunction as functions.CloudFunction<any>;
       };
-      const wrapped = wrap(constructCF());
-      const context = wrapped('data', { params }).context;
-      expect(context.params).to.deep.equal(params);
-      expect(context.resource.name).to.equal('ref/a/nested/b');
+
+      it('should invoke the function with the supplied data', () => {
+        const wrapped = wrap(constructBackgroundCF());
+        expect(wrapped('data').data).to.equal('data');
+      });
+
+      it('should generate the appropriate context if no fields specified', () => {
+        const context = wrap(constructBackgroundCF())('data').context;
+        expect(typeof context.eventId).to.equal('string');
+        expect(context.resource.service).to.equal('service');
+        expect(
+            /ref\/wildcard[1-9]\/nested\/anotherWildcard[1-9]/.test(
+                context.resource.name
+            )
+        ).to.be.true;
+        expect(context.eventType).to.equal('event');
+        expect(Date.parse(context.timestamp)).to.be.greaterThan(0);
+        expect(context.params).to.deep.equal({});
+        expect(context.auth).to.be.undefined;
+        expect(context.authType).to.be.undefined;
+      });
+
+      it('should allow specification of context fields', () => {
+        const wrapped = wrap(constructBackgroundCF());
+        const context = wrapped('data', {
+          eventId: '111',
+          timestamp: '2018-03-28T18:58:50.370Z',
+        }).context;
+        expect(context.eventId).to.equal('111');
+        expect(context.timestamp).to.equal('2018-03-28T18:58:50.370Z');
+      });
+
+      it('should generate auth and authType for database functions', () => {
+        const context = wrap(constructBackgroundCF('google.firebase.database.ref.write'))(
+            'data'
+        ).context;
+        expect(context.auth).to.equal(null);
+        expect(context.authType).to.equal('UNAUTHENTICATED');
+      });
+
+      it('should allow auth and authType to be specified for database functions', () => {
+        const wrapped = wrap(constructBackgroundCF('google.firebase.database.ref.write'));
+        const context = wrapped('data', {
+          auth: { uid: 'abc' },
+          authType: 'USER',
+        }).context;
+        expect(context.auth).to.deep.equal({ uid: 'abc' });
+        expect(context.authType).to.equal('USER');
+      });
+
+      it('should throw when passed invalid options', () => {
+        const wrapped = wrap(constructBackgroundCF());
+        expect(() =>
+            wrapped('data', {
+              auth: { uid: 'abc' },
+              isInvalid: true,
+            } as any)
+        ).to.throw();
+      });
+
+      it('should generate the appropriate resource based on params', () => {
+        const params = {
+          wildcard: 'a',
+          anotherWildcard: 'b',
+        };
+        const wrapped = wrap(constructBackgroundCF());
+        const context = wrapped('data', { params }).context;
+        expect(context.params).to.deep.equal(params);
+        expect(context.resource.name).to.equal('ref/a/nested/b');
+      });
+    });
+
+    describe('callable functions', () => {
+      let wrappedCF;
+
+      before(() => {
+        const cloudFunction = (input) => input;
+        set(cloudFunction, 'run', (data, context) => {
+          return { data, context };
+        });
+        set(cloudFunction, '__trigger', {
+          labels: {
+            'deployment-callable': 'true',
+          },
+          httpsTrigger: {},
+        });
+        wrappedCF = wrap(cloudFunction as functions.CloudFunction<any>);
+      });
+
+      it('should invoke the function with the supplied data', () => {
+        expect(wrappedCF('data').data).to.equal('data');
+      });
+
+      it('should allow specification of context fields', () => {
+        const context = wrappedCF('data', {
+          auth: { uid: 'abc' },
+          app: { appId: 'efg' },
+          instanceIdToken: '123',
+          rawRequest: { body: 'hello' }
+        }).context;
+        expect(context.auth).to.deep.equal({ uid: 'abc' });
+        expect(context.app).to.deep.equal({ appId: 'efg' });
+        expect(context.instanceIdToken).to.equal('123');
+        expect(context.rawRequest).to.deep.equal({ body: 'hello'});
+      });
+
+      it('should throw when passed invalid options', () => {
+        expect(() =>
+            wrappedCF('data', {
+              auth: { uid: 'abc' },
+              isInvalid: true,
+            } as any)
+        ).to.throw();
+      });
+
     });
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,11 @@ export type EventContextOptions = {
 /** Fields of the callable context that can be overridden/customized. */
 export type CallableContextOptions = {
   /**
+   * The result of decoding and verifying a Firebase AppCheck token.
+   */
+  app?: any;
+
+  /**
    * The result of decoding and verifying a Firebase Auth ID token.
    */
   auth?: any;
@@ -149,7 +154,7 @@ export function wrap<T>(
     let context;
 
     if (isCallableFunction) {
-      _checkOptionValidity(['auth', 'instanceIdToken', 'rawRequest'], options);
+      _checkOptionValidity(['app', 'auth', 'instanceIdToken', 'rawRequest'], options);
       let callableContextOptions = options as CallableContextOptions;
       context = {
         ...callableContextOptions,


### PR DESCRIPTION
Change allows users to pass `app` property in the mocked callable context, e.g.

```js
export myFunc = functions.https.onCall((data, context) => {
  if (context.app == undefined) {
    throw new functions.https.HttpsError(
        'failed-precondition',
        'The function must be called from an App Check verified app.')
  }
});
```

### Before
```js
wrap(myFunc)('data', { app: { appId: 'my-app-123' }});
// => Options object {"auth":{"uid":""},"app":{}} has invalid key "app"
```

### After
```js
wrap(myFunc)('data', { app: { appId: 'my-app-123' }});
// no error
```

The diff on `main.spec.ts` looks terrible - I'm just adding a few test cases for callable functions, and indenting the ones that existed before.

Fixes https://github.com/firebase/firebase-functions-test/issues/122