### PR TITLE
Update wrappedFunction return type can be promise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,22 +93,22 @@ export type ContextOptions = EventContextOptions | CallableContextOptions;
 /** A function that can be called with test data and optional override values for the event context.
  * It will subsequently invoke the cloud function it wraps with the provided test data and a generated event context.
  */
-export type WrappedFunction = (
+export type WrappedFunction<T = any> = (
   data: any,
   options?: ContextOptions
-) => any | Promise<any>;
+) => T;
 
 /** A scheduled function that can be called with optional override values for the event context.
  * It will subsequently invoke the cloud function it wraps with a generated event context.
  */
-export type WrappedScheduledFunction = (
+export type WrappedScheduledFunction<T = any> = (
   options?: ContextOptions
-) => any | Promise<any>;
+) => T;
 
 /** Takes a cloud function to be tested, and returns a WrappedFunction which can be called in test code. */
 export function wrap<T>(
   cloudFunction: CloudFunction<T>
-): WrappedScheduledFunction | WrappedFunction {
+): WrappedScheduledFunction<T> | WrappedFunction<T> {
   if (!has(cloudFunction, '__trigger')) {
     throw new Error(
       'Wrap can only be called on functions written with the firebase-functions SDK.'


### PR DESCRIPTION
### Following changes
- add WrappedFunction & WrappedScheduledFunction "generic"
- change WrappedFunction & WrappedScheduledFunction's return type "any | Promise\<any\>" to "T"

### Problem
In the v0.3.3 `wrap()()` this function's return type will be any. so when I test promise function using by chai.should, Automatic completion doesn't work.
![image](https://user-images.githubusercontent.com/48207131/149509066-cf083957-96c7-452e-8bcb-c6a4be7cbc2b.png)


### Solution
Return type ```any | Promise<any>``` must be any. So I use generic to "Promiseable"
https://github.com/firebase/firebase-functions-test/blob/c1dd82b84f5fe4126ca666577a04a7d72e96f2fc/src/main.ts#L96-L99
change to 
```ts
export type WrappedFunction<T = any> = (
  data: any,
  options?: ContextOptions
) => T;
```
then I can use like that
![image](https://user-images.githubusercontent.com/48207131/149510692-32afcaf2-55c8-4a0c-80f4-3c069cdb6159.png)
![image](https://user-images.githubusercontent.com/48207131/149510721-d62239e6-d749-467e-bbfb-4715bb058f2d.png)


