### PR TITLE
Add top-level bucket field to Mock Storage CloudEvents

### DIFF
--- a/spec/v2.spec.ts
+++ b/spec/v2.spec.ts
@@ -134,30 +134,42 @@ describe('v2', () => {
     describe('storage', () => {
       describe('storage.onObjectArchived()', () => {
         it('should update CloudEvent appropriately', () => {
-          const cloudFn = storage.onObjectArchived('bucket', handler);
+          const bucket = 'bucket';
+          const cloudFn = storage.onObjectArchived(bucket, handler);
           const cloudFnWrap = wrapV2(cloudFn);
-          expect(cloudFnWrap().cloudEvent).to.include({});
+          expect(cloudFnWrap().cloudEvent).to.include({
+            bucket,
+          });
         });
       });
       describe('storage.onObjectDeleted()', () => {
         it('should update CloudEvent appropriately', () => {
-          const cloudFn = storage.onObjectDeleted('bucket', handler);
+          const bucket = 'bucket';
+          const cloudFn = storage.onObjectDeleted(bucket, handler);
           const cloudFnWrap = wrapV2(cloudFn);
-          expect(cloudFnWrap().cloudEvent).to.include({});
+          expect(cloudFnWrap().cloudEvent).to.include({
+            bucket,
+          });
         });
       });
       describe('storage.onObjectFinalized()', () => {
         it('should update CloudEvent appropriately', () => {
-          const cloudFn = storage.onObjectFinalized('bucket', handler);
+          const bucket = 'bucket';
+          const cloudFn = storage.onObjectFinalized(bucket, handler);
           const cloudFnWrap = wrapV2(cloudFn);
-          expect(cloudFnWrap().cloudEvent).to.include({});
+          expect(cloudFnWrap().cloudEvent).to.include({
+            bucket,
+          });
         });
       });
       describe('storage.onObjectMetadataUpdated()', () => {
         it('should update CloudEvent appropriately', () => {
-          const cloudFn = storage.onObjectMetadataUpdated('bucket', handler);
+          const bucket = 'bucket';
+          const cloudFn = storage.onObjectMetadataUpdated(bucket, handler);
           const cloudFnWrap = wrapV2(cloudFn);
-          expect(cloudFnWrap().cloudEvent).to.include({});
+          expect(cloudFnWrap().cloudEvent).to.include({
+            bucket,
+          });
         });
       });
     });

--- a/src/cloudevent/partials/storage/index.ts
+++ b/src/cloudevent/partials/storage/index.ts
@@ -13,6 +13,7 @@ export const storageV1: MockCloudEventPartials<StorageEvent> = {
     const subject = `objects/${FILENAME}`;
 
     return {
+      bucket,
       source,
       subject,
       data: getStorageObjectData(bucket, FILENAME, 1),


### PR DESCRIPTION
### Description

Storage CloudEvents contain a "bucket" field. The mock data should
return this "bucket" field to accurately reflect live data.

[More info here](https://github.com/firebase/firebase-functions/blob/27a49837ea7b74d9d2926e74c387f45704d57889/src/v2/providers/storage.ts#L185)
