### PR TITLE
Add CI for firebase-functions-test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
-          - 12.x
           - 14.x
           - 16.x
     steps:
@@ -38,7 +36,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
           - 14.x
           - 16.x
     steps:
@@ -54,4 +51,4 @@ jobs:
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
 
       - run: npm install
-      - run: npm run test:bin
+      - run: npm run integrationTest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,57 @@
+name: CI Tests
+
+on:
+  - pull_request
+  - push
+
+env:
+  CI: true
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 10.x
+          - 12.x
+          - 14.x
+          - 16.x
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache npm
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format
+      - run: npm run test
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 12.x
+          - 14.x
+          - 16.x
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache npm
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+
+      - run: npm install
+      - run: npm run test:bin

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -24,15 +24,8 @@ import { expect } from 'chai';
 import * as functions from 'firebase-functions';
 import { set } from 'lodash';
 
-import {
-  mockConfig,
-  makeChange,
-  wrap,
-} from '../src/main';
-import {
-  _makeResourceName,
-  _extractParams,
-} from '../src/v1';
+import { mockConfig, makeChange, wrap } from '../src/main';
+import { _makeResourceName, _extractParams } from '../src/v1';
 import { features } from '../src/features';
 import { FirebaseFunctionsTest } from '../src/lifecycle';
 import { alerts } from 'firebase-functions/v2';


### PR DESCRIPTION
This commit adds CI for firebase-functions-test as an additional level
of protection.

This is a duplicate of the {test.yaml from firebase-functions](https://github.com/firebase/firebase-functions/blob/master/.github/workflows/test.yaml)