### PR TITLE
Update Rtdb test sdk to allow json for CloudEvent

### DIFF
--- a/spec/v2.spec.ts
+++ b/spec/v2.spec.ts
@@ -522,6 +522,19 @@ describe('v2', () => {
 
           expect(cloudEvent.data.val()).deep.equal(dataVal);
         });
+
+        it('should accept json data', () => {
+          const referenceOptions = {
+            ref: 'foo/bar',
+            instance: 'instance-1',
+          };
+          const cloudFn = database.onValueCreated(referenceOptions, handler);
+          const cloudFnWrap = wrapV2(cloudFn);
+          const dataVal = { snapshot: 'override' };
+          const cloudEvent = cloudFnWrap({ data: dataVal }).cloudEvent;
+
+          expect(cloudEvent.data.val()).deep.equal(dataVal);
+        });
       });
 
       describe('database.onValueDeleted()', () => {
@@ -560,6 +573,19 @@ describe('v2', () => {
           const dataVal = { snapshot: 'override' };
           const data = makeDataSnapshot(dataVal, referenceOptions.ref);
           const cloudEvent = cloudFnWrap({ data }).cloudEvent;
+
+          expect(cloudEvent.data.val()).deep.equal(dataVal);
+        });
+
+        it('should accept json data', () => {
+          const referenceOptions = {
+            ref: 'foo/bar',
+            instance: 'instance-1',
+          };
+          const cloudFn = database.onValueDeleted(referenceOptions, handler);
+          const cloudFnWrap = wrapV2(cloudFn);
+          const dataVal = { snapshot: 'override' };
+          const cloudEvent = cloudFnWrap({ data: dataVal }).cloudEvent;
 
           expect(cloudEvent.data.val()).deep.equal(dataVal);
         });
@@ -610,6 +636,23 @@ describe('v2', () => {
           expect(cloudEvent.data.before.val()).deep.equal(beforeDataVal);
           expect(cloudEvent.data.after.val()).deep.equal(afterDataVal);
         });
+
+        it('should accept json data', () => {
+          const referenceOptions = {
+            ref: 'foo/bar',
+            instance: 'instance-1',
+          };
+          const cloudFn = database.onValueUpdated(referenceOptions, handler);
+          const cloudFnWrap = wrapV2(cloudFn);
+          const afterDataVal = { snapshot: 'after' };
+          const beforeDataVal = { snapshot: 'before' };
+          const data = { before: beforeDataVal, after: afterDataVal };
+
+          const cloudEvent = cloudFnWrap({ data }).cloudEvent;
+
+          expect(cloudEvent.data.before.val()).deep.equal(beforeDataVal);
+          expect(cloudEvent.data.after.val()).deep.equal(afterDataVal);
+        });
       });
 
       describe('database.onValueWritten()', () => {
@@ -652,6 +695,24 @@ describe('v2', () => {
           const before = makeDataSnapshot(beforeDataVal, referenceOptions.ref);
 
           const data = { before, after };
+          const cloudEvent = cloudFnWrap({ data }).cloudEvent;
+
+          expect(cloudEvent.data.before.val()).deep.equal(beforeDataVal);
+          expect(cloudEvent.data.after.val()).deep.equal(afterDataVal);
+        });
+
+        it('should accept json data', () => {
+          const referenceOptions = {
+            ref: 'foo/bar',
+            instance: 'instance-1',
+          };
+          const cloudFn = database.onValueWritten(referenceOptions, handler);
+          const cloudFnWrap = wrapV2(cloudFn);
+          const afterDataVal = { snapshot: 'after' };
+
+          const beforeDataVal = { snapshot: 'before' };
+
+          const data = { before: beforeDataVal, after: afterDataVal };
           const cloudEvent = cloudFnWrap({ data }).cloudEvent;
 
           expect(cloudEvent.data.before.val()).deep.equal(beforeDataVal);

--- a/src/cloudevent/generate.ts
+++ b/src/cloudevent/generate.ts
@@ -1,8 +1,11 @@
-import { CloudEvent, pubsub } from 'firebase-functions/v2';
-import { CloudFunction } from 'firebase-functions/v2';
+import {
+  CloudEvent,
+  CloudFunction,
+  database,
+  pubsub,
+} from 'firebase-functions/v2';
 import { LIST_OF_MOCK_CLOUD_EVENT_PARTIALS } from './mocks/partials';
 import { DeepPartial } from './types';
-import { database } from 'firebase-functions/v2';
 import { Change } from 'firebase-functions';
 import merge from 'ts-deepmerge';
 
@@ -45,7 +48,7 @@ function mergeCloudEvents<EventType extends CloudEvent<unknown>>(
   cloudEventPartial: DeepPartial<EventType>
 ) {
   /**
-   * There are several CloudEvent.data types that can not be overridden with PoJson.
+   * There are several CloudEvent.data types that can not be overridden with json.
    * In these circumstances, we generate the CloudEvent.data given the user supplies
    * in the DeepPartial<CloudEvent>.
    *
@@ -72,7 +75,7 @@ function shouldDeleteUserSuppliedData<EventType extends CloudEvent<unknown>>(
   if (cloudEventPartial?.data === undefined) {
     return false;
   }
-  /** If the user intentionally provides one of the IMMUTABLE DataTypes, DON'T delete it! */
+  // If the user intentionally provides one of the IMMUTABLE DataTypes, DON'T delete it!
   if (
     IMMUTABLE_DATA_TYPES.some((type) => cloudEventPartial?.data instanceof type)
   ) {

--- a/src/cloudevent/generate.ts
+++ b/src/cloudevent/generate.ts
@@ -1,7 +1,9 @@
-import { CloudEvent } from 'firebase-functions/v2';
+import { CloudEvent, pubsub } from 'firebase-functions/v2';
 import { CloudFunction } from 'firebase-functions/v2';
 import { LIST_OF_MOCK_CLOUD_EVENT_PARTIALS } from './mocks/partials';
-import { DeepPartial, MockCloudEventAbstractFactory } from './types';
+import { DeepPartial } from './types';
+import { database } from 'firebase-functions/v2';
+import { Change } from 'firebase-functions';
 import merge from 'ts-deepmerge';
 
 /**
@@ -17,9 +19,7 @@ export function generateCombinedCloudEvent<
     cloudFunction,
     cloudEventPartial
   );
-  return cloudEventPartial
-    ? (merge(generatedCloudEvent, cloudEventPartial) as EventType)
-    : generatedCloudEvent;
+  return mergeCloudEvents(generatedCloudEvent, cloudEventPartial);
 }
 
 export function generateMockCloudEvent<EventType extends CloudEvent<unknown>>(
@@ -36,4 +36,60 @@ export function generateMockCloudEvent<EventType extends CloudEvent<unknown>>(
   }
   // No matches were found
   return null;
+}
+
+const IMMUTABLE_DATA_TYPES = [database.DataSnapshot, Change, pubsub.Message];
+
+function mergeCloudEvents<EventType extends CloudEvent<unknown>>(
+  generatedCloudEvent: EventType,
+  cloudEventPartial: DeepPartial<EventType>
+) {
+  /**
+   * There are several CloudEvent.data types that can not be overridden with PoJson.
+   * In these circumstances, we generate the CloudEvent.data given the user supplies
+   * in the DeepPartial<CloudEvent>.
+   *
+   * Because we have already extracted the user supplied data, we don't want to overwrite
+   * the CloudEvent.data with an incompatible type.
+   *
+   * An example of this is a user supplying JSON for the data of the DatabaseEvents.
+   * The returned CloudEvent should be returning DataSnapshot that uses the supplied json,
+   * NOT the supplied JSON.
+   */
+  if (shouldDeleteUserSuppliedData(generatedCloudEvent, cloudEventPartial)) {
+    delete cloudEventPartial.data;
+  }
+  return cloudEventPartial
+    ? (merge(generatedCloudEvent, cloudEventPartial) as EventType)
+    : generatedCloudEvent;
+}
+
+function shouldDeleteUserSuppliedData<EventType extends CloudEvent<unknown>>(
+  generatedCloudEvent: EventType,
+  cloudEventPartial: DeepPartial<EventType>
+) {
+  // Don't attempt to delete the data if there is no data.
+  if (cloudEventPartial?.data === undefined) {
+    return false;
+  }
+  /** If the user intentionally provides one of the IMMUTABLE DataTypes, DON'T delete it! */
+  if (
+    IMMUTABLE_DATA_TYPES.some((type) => cloudEventPartial?.data instanceof type)
+  ) {
+    return false;
+  }
+
+  /** If the generated CloudEvent.data is an IMMUTABLE DataTypes, then use the generated data and
+   * delete the user supplied CloudEvent.data.
+   */
+  if (
+    IMMUTABLE_DATA_TYPES.some(
+      (type) => generatedCloudEvent?.data instanceof type
+    )
+  ) {
+    return true;
+  }
+
+  // Otherwise, don't delete the data and allow ts-merge to handle merging the data.
+  return false;
 }

--- a/src/cloudevent/mocks/database/helpers.ts
+++ b/src/cloudevent/mocks/database/helpers.ts
@@ -9,7 +9,7 @@ import { Change } from 'firebase-functions';
 import { makeDataSnapshot } from '../../../providers/database';
 
 function getOrCreateDataSnapshot(
-  data: database.DataSnapshot | object,
+  data: database.DataSnapshot | Object,
   ref: string
 ) {
   if (data instanceof database.DataSnapshot) {

--- a/src/cloudevent/mocks/database/helpers.ts
+++ b/src/cloudevent/mocks/database/helpers.ts
@@ -6,10 +6,41 @@ import {
 } from '../../../providers/database';
 import { getBaseCloudEvent } from '../helpers';
 import { Change } from 'firebase-functions';
+import { makeDataSnapshot } from '../../../providers/database';
+
+function getOrCreateDataSnapshot(
+  data: database.DataSnapshot | object,
+  ref: string
+) {
+  if (data instanceof database.DataSnapshot) {
+    return data;
+  }
+  if (data instanceof Object) {
+    return makeDataSnapshot(data, ref);
+  }
+  return exampleDataSnapshot(ref);
+}
+
+function getOrCreateDataSnapshotChange(
+  data: Change<database.DataSnapshot> | any,
+  ref: string
+) {
+  if (data instanceof Change) {
+    return data;
+  }
+  if (data instanceof Object && data?.before && data?.after) {
+    const beforeDataSnapshot = getOrCreateDataSnapshot(data.before, ref);
+    const afterDataSnapshot = getOrCreateDataSnapshot(data.after, ref);
+    return new Change(beforeDataSnapshot, afterDataSnapshot);
+  }
+  return exampleDataSnapshotChange(ref);
+}
 
 export function getDatabaseSnapshotCloudEvent(
   cloudFunction: CloudFunction<database.DatabaseEvent<database.DataSnapshot>>,
-  cloudEventPartial?: DeepPartial<database.DatabaseEvent<database.DataSnapshot>>
+  cloudEventPartial?: DeepPartial<
+    database.DatabaseEvent<database.DataSnapshot | object>
+  >
 ) {
   const {
     instance,
@@ -19,9 +50,7 @@ export function getDatabaseSnapshotCloudEvent(
     params,
   } = getCommonDatabaseFields(cloudFunction, cloudEventPartial);
 
-  const data =
-    (cloudEventPartial?.data as database.DataSnapshot) ||
-    exampleDataSnapshot(ref);
+  const data = getOrCreateDataSnapshot(cloudEventPartial?.data, ref);
 
   return {
     // Spread common fields
@@ -43,7 +72,7 @@ export function getDatabaseChangeSnapshotCloudEvent(
     database.DatabaseEvent<Change<database.DataSnapshot>>
   >,
   cloudEventPartial?: DeepPartial<
-    database.DatabaseEvent<Change<database.DataSnapshot>>
+    database.DatabaseEvent<Change<database.DataSnapshot> | object>
   >
 ): database.DatabaseEvent<Change<database.DataSnapshot>> {
   const {
@@ -54,9 +83,7 @@ export function getDatabaseChangeSnapshotCloudEvent(
     params,
   } = getCommonDatabaseFields(cloudFunction, cloudEventPartial);
 
-  const data =
-    (cloudEventPartial?.data as Change<database.DataSnapshot>) ||
-    exampleDataSnapshotChange(ref);
+  const data = getOrCreateDataSnapshotChange(cloudEventPartial?.data, ref);
 
   return {
     // Spread common fields

--- a/src/cloudevent/mocks/database/helpers.ts
+++ b/src/cloudevent/mocks/database/helpers.ts
@@ -8,8 +8,13 @@ import { getBaseCloudEvent } from '../helpers';
 import { Change } from 'firebase-functions';
 import { makeDataSnapshot } from '../../../providers/database';
 
+type ChangeLike = {
+  before: database.DataSnapshot | object;
+  after: database.DataSnapshot | object;
+};
+
 function getOrCreateDataSnapshot(
-  data: database.DataSnapshot | Object,
+  data: database.DataSnapshot | object,
   ref: string
 ) {
   if (data instanceof database.DataSnapshot) {
@@ -22,15 +27,15 @@ function getOrCreateDataSnapshot(
 }
 
 function getOrCreateDataSnapshotChange(
-  data: Change<database.DataSnapshot> | any,
+  data: DeepPartial<Change<database.DataSnapshot> | ChangeLike>,
   ref: string
 ) {
   if (data instanceof Change) {
     return data;
   }
   if (data instanceof Object && data?.before && data?.after) {
-    const beforeDataSnapshot = getOrCreateDataSnapshot(data.before, ref);
-    const afterDataSnapshot = getOrCreateDataSnapshot(data.after, ref);
+    const beforeDataSnapshot = getOrCreateDataSnapshot(data!.before, ref);
+    const afterDataSnapshot = getOrCreateDataSnapshot(data!.after, ref);
     return new Change(beforeDataSnapshot, afterDataSnapshot);
   }
   return exampleDataSnapshotChange(ref);
@@ -72,7 +77,7 @@ export function getDatabaseChangeSnapshotCloudEvent(
     database.DatabaseEvent<Change<database.DataSnapshot>>
   >,
   cloudEventPartial?: DeepPartial<
-    database.DatabaseEvent<Change<database.DataSnapshot> | object>
+    database.DatabaseEvent<Change<database.DataSnapshot> | ChangeLike>
   >
 ): database.DatabaseEvent<Change<database.DataSnapshot>> {
   const {

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -29,7 +29,7 @@ import { DeepPartial } from './cloudevent/types';
  * It will subsequently invoke the cloud function it wraps with the provided {@link CloudEvent}
  */
 export type WrappedV2Function<T extends CloudEvent<unknown>> = (
-  cloudEventPartial?: DeepPartial<T>
+  cloudEventPartial?: DeepPartial<T | object>
 ) => any | Promise<any>;
 
 /**


### PR DESCRIPTION
### Description

This commit updates the test sdk api for the Database CloudEventPartial
to support end-users submitting JSON that gets transformed into `DataSnapshot`
instead of forcing users to import and use `Change` and `DataSnapshot` to
mock out the CloudEvent resopnses.

### Code sample


```
// Previous example
const cloudFn = database.onValueDeleted(referenceOptions, handler);
const cloudFnWrap = wrapV2(cloudFn);
const dataVal = { snapshot: 'override' };

// Calling makeDataSnapshot is the step we are trying to simplify
const data = makeDataSnapshot(dataVal, referenceOptions.ref);

cloudFnWrap({ data: data });
```

```
// New example
const cloudFn = database.onValueDeleted(referenceOptions, handler);
const cloudFnWrap = wrapV2(cloudFn);
const dataVal = { snapshot: 'override' };

cloudFnWrap({ data: dataVal });
```