### PR TITLE
Update mockConfig function for v4 firebase-functions

### DIFF
--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -340,11 +340,5 @@ describe('main', () => {
 
       expect(functions.config()).to.deep.equal(config);
     });
-
-    it('should not throw an error when functions.config.singleton is missing', () => {
-      delete functions.config.singleton;
-
-      expect(() => mockConfig(config)).to.not.throw(Error);
-    });
   });
 });

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -345,9 +345,14 @@ export function makeChange<T>(before: T, after: T): Change<T> {
 
 /** Mock values returned by `functions.config()`. */
 export function mockConfig(conf: { [key: string]: { [key: string]: any } }) {
-  if (config.singleton) {
-    delete config.singleton;
+  const resetCache = require('firebase-functions').resetCache;
+  if (resetCache) {
+    resetCache();
+  } else {
+    // Older versions of firebase-functions directly manipulated the config singleton
+    if ((config as any).singleton) {
+      delete (config as any).singleton;
+    }
   }
-
   process.env.CLOUD_RUNTIME_CONFIG = JSON.stringify(conf);
 }

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -32,6 +32,8 @@ import {
   firestore,
   HttpsFunction,
   Runnable,
+  // @ts-ignore
+  resetCache,
 } from 'firebase-functions';
 
 /** Fields of the event context that can be overridden/customized. */
@@ -345,14 +347,8 @@ export function makeChange<T>(before: T, after: T): Change<T> {
 
 /** Mock values returned by `functions.config()`. */
 export function mockConfig(conf: { [key: string]: { [key: string]: any } }) {
-  const resetCache = require('firebase-functions').resetCache;
   if (resetCache) {
     resetCache();
-  } else {
-    // Older versions of firebase-functions directly manipulated the config singleton
-    if ((config as any).singleton) {
-      delete (config as any).singleton;
-    }
   }
   process.env.CLOUD_RUNTIME_CONFIG = JSON.stringify(conf);
 }


### PR DESCRIPTION
V4 Functions SDK does not expose the config singleton directly.

Use the internal-only `resetCache` function instead.