### PR TITLE
BREAKING: Drop support for Firebase Functions SDK v3 and below - take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## BREAKING
+* Drop support for Firebase Functions SDK v3 and below.
+* Drop support for Firebase Admin SDK v7 and below.

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "typescript": "^4.2.5"
   },
   "peerDependencies": {
-    "firebase-admin": ">=6.0.0",
-    "firebase-functions": ">=3.23.0",
+    "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+    "firebase-functions": "^4.0.0",
     "jest": ">=28.0.0"
   },
   "engines": {


### PR DESCRIPTION
Redo https://github.com/firebase/firebase-functions-test/pull/174, targeting the correct `launch.next` branch.