### PR TITLE
fix(firestore): use hostname from env variable

### DIFF
--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -1,13 +1,29 @@
 import { expect } from 'chai';
 import * as firebase from 'firebase-admin';
+import * as sinon from 'sinon';
+import * as http from 'http';
 import { FeaturesList } from '../../src/features';
 import fft = require('../../src/index');
 
 describe('providers/firestore', () => {
   let test: FeaturesList;
+  let fakeHttpRequestMethod;
+  let fakeHttpResponse;
 
   beforeEach(() => {
     test = fft();
+    fakeHttpResponse = {
+      statusCode: 200,
+      on: ((event, cb) => cb())
+    };
+    fakeHttpRequestMethod = sinon.fake((config, cb) => {
+      cb(fakeHttpResponse);
+    });
+    sinon.replace(http, 'request', fakeHttpRequestMethod);
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it('produces the right snapshot with makeDocumentSnapshot', async () => {
@@ -70,5 +86,31 @@ describe('providers/firestore', () => {
       firebase.firestore.DocumentReference
     );
     expect(snapshot.data().ref.toString()).to.equal(ref.toString());
+  });
+
+  it('should use host name from FIRESTORE_EMULATOR_HOST env in clearFirestoreData', async () => {
+    process.env.FIRESTORE_EMULATOR_HOST = 'not-local-host:8080';
+
+    await test.firestore.clearFirestoreData({projectId: 'not-a-project'});
+
+    expect(fakeHttpRequestMethod.calledOnceWith({
+      hostname: 'not-local-host',
+      method: 'DELETE',
+      path: '/emulator/v1/projects/not-a-project/databases/(default)/documents',
+      port: '8080'
+    })).to.be.true;
+  });
+
+  it('should use host name from FIREBASE_FIRESTORE_EMULATOR_ADDRESS env in clearFirestoreData', async () => {
+    process.env.FIREBASE_FIRESTORE_EMULATOR_ADDRESS = 'custom-host:9090';
+
+    await test.firestore.clearFirestoreData({projectId: 'not-a-project'});
+
+    expect(fakeHttpRequestMethod.calledOnceWith({
+      hostname: 'custom-host',
+      method: 'DELETE',
+      path: '/emulator/v1/projects/not-a-project/databases/(default)/documents',
+      port: '9090'
+    })).to.be.true;
   });
 });

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -250,15 +250,14 @@ const FIRESTORE_ADDRESS_ENVS = [
   'FIREBASE_FIRESTORE_EMULATOR_ADDRESS',
 ];
 
-const FIRESTORE_ADDRESS = FIRESTORE_ADDRESS_ENVS.reduce(
-  (addr, name) => process.env[name] || addr,
-  'localhost:8080'
-);
-const FIRESTORE_PORT = FIRESTORE_ADDRESS.split(':')[1];
-
 /** Clears all data in firestore. Works only in offline mode.
  */
 export function clearFirestoreData(options: { projectId: string } | string) {
+  const FIRESTORE_ADDRESS = FIRESTORE_ADDRESS_ENVS.reduce(
+    (addr, name) => process.env[name] || addr,
+    'localhost:8080'
+  );
+
   return new Promise((resolve, reject) => {
     let projectId;
 
@@ -272,8 +271,8 @@ export function clearFirestoreData(options: { projectId: string } | string) {
 
     const config = {
       method: 'DELETE',
-      hostname: 'localhost',
-      port: FIRESTORE_PORT,
+      hostname: FIRESTORE_ADDRESS.split(':')[0],
+      port: FIRESTORE_ADDRESS.split(':')[1],
       path: `/emulator/v1/projects/${projectId}/databases/(default)/documents`,
     };
 


### PR DESCRIPTION
### Description

Remove hardcoded firestore hostname from clearFirestoreData function and make possibility to configure it via FIRESTORE_EMULATOR_HOST environment variable
