### PR TITLE
Improve cleanup type definition

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -5,6 +5,7 @@ import * as database from './providers/database';
 import * as firestore from './providers/firestore';
 import * as pubsub from './providers/pubsub';
 import * as storage from './providers/storage';
+import { FirebaseFunctionsTest } from './lifecycle';
 
 export interface LazyFeatures {
   mockConfig: typeof mockConfig;
@@ -31,5 +32,5 @@ export const features: LazyFeatures = {
 };
 
 export interface FeaturesList extends LazyFeatures {
-  cleanup;
+  cleanup: InstanceType<typeof FirebaseFunctionsTest>['cleanup'];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,16 +24,19 @@ import { AppOptions } from 'firebase-admin';
 import { merge } from 'lodash';
 
 import { FirebaseFunctionsTest } from './lifecycle';
-import { features as lazyFeatures, FeaturesList } from './features';
+import { FeaturesList } from './features';
 
-export = (firebaseConfig?: AppOptions, pathToServiceAccountKey?: string) => {
+export = (
+  firebaseConfig?: AppOptions,
+  pathToServiceAccountKey?: string
+): FeaturesList => {
   const test = new FirebaseFunctionsTest();
   test.init(firebaseConfig, pathToServiceAccountKey);
   // Ensure other files get loaded after init function, since they load `firebase-functions`
   // which will issue warning if process.env.FIREBASE_CONFIG is not yet set.
-  let features = require('./features').features as typeof lazyFeatures;
+  let features = require('./features').features;
   features = merge({}, features, {
     cleanup: () => test.cleanup(),
   });
-  return features as FeaturesList;
+  return features;
 };


### PR DESCRIPTION
### Description

Right pull improves type definition for cleanup method.

Before:
```typescript
import firebase_function_test from 'firebase-functions-test';
const ffTest = firebase_function_test();
// eslint-disable-next-line @typescript-eslint/no-unsafe-call
ffTest.cleanup();
```

After
```typescript
import firebase_function_test from 'firebase-functions-test';
const ffTest = firebase_function_test();
ffTest.cleanup();
```