### PR TITLE
Add changelog entry for #227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Add support for testing Firestore 2nd gen Auth Context triggers. (#227)


### PR DESCRIPTION
We forgot the changelog entry for #227. There are no other changes slated for release, so the publish workflow won't run with the changelog empty.