### PR TITLE
Update to firebase-functions 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/mocha": "^5.2.7",
         "chai": "^4.2.0",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^4.9.0",
+        "firebase-functions": "^6.0.1",
         "firebase-tools": "^8.9.2",
         "mocha": "^6.2.2",
         "prettier": "^1.19.1",
@@ -32,7 +32,7 @@
       },
       "peerDependencies": {
         "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-        "firebase-functions": ">=4.9.0",
+        "firebase-functions": ">=6.0.1",
         "jest": ">=28.0.0"
       }
     },
@@ -5435,10 +5435,11 @@
       "dev": true
     },
     "node_modules/firebase-functions": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.9.0.tgz",
-      "integrity": "sha512-IqxOEsVAWGcRv9KRGzWQR5mOFuNsil3vsfkRPPiaV1U/ATC27/jbahh4z8I4rW8Xqa6cQE5xqnw0ueyMH7i7Ag==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.0.1.tgz",
+      "integrity": "sha512-0rIpTU6dnLRvP3IK+okn1FDjoqjzShm0/S+i4OMY7JFu/HJoyJ1JNkrT4KjECy1/mCHK49KsmH8iYE0rzrglHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -5453,7 +5454,7 @@
         "node": ">=14.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^10.0.0 || ^11.0.0 || ^12.0.0"
+        "firebase-admin": "^11.10.0 || ^12.0.0"
       }
     },
     "node_modules/firebase-functions/node_modules/@types/express": {
@@ -17805,9 +17806,9 @@
       }
     },
     "firebase-functions": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.9.0.tgz",
-      "integrity": "sha512-IqxOEsVAWGcRv9KRGzWQR5mOFuNsil3vsfkRPPiaV1U/ATC27/jbahh4z8I4rW8Xqa6cQE5xqnw0ueyMH7i7Ag==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.0.1.tgz",
+      "integrity": "sha512-0rIpTU6dnLRvP3IK+okn1FDjoqjzShm0/S+i4OMY7JFu/HJoyJ1JNkrT4KjECy1/mCHK49KsmH8iYE0rzrglHg==",
       "dev": true,
       "requires": {
         "@types/cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^4.9.0",
+    "firebase-functions": "^6.0.1",
     "firebase-tools": "^8.9.2",
     "mocha": "^6.2.2",
     "prettier": "^1.19.1",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-    "firebase-functions": ">=4.9.0",
+    "firebase-functions": ">=6.0.1",
     "jest": ">=28.0.0"
   },
   "engines": {

--- a/spec/cloudevent/generate.ts
+++ b/spec/cloudevent/generate.ts
@@ -22,7 +22,7 @@
 
 import { expect } from 'chai';
 
-import { alerts, storage } from 'firebase-functions/v2';
+import { alerts, storage } from 'firebase-functions';
 import { generateMockCloudEvent } from '../../src/cloudevent/generate';
 
 describe('generate (CloudEvent)', () => {

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -21,14 +21,14 @@
 // SOFTWARE.
 
 import { expect } from 'chai';
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 import { set } from 'lodash';
 
 import { mockConfig, makeChange, wrap } from '../src/main';
 import { _makeResourceName, _extractParams } from '../src/v1';
 import { features } from '../src/features';
 import { FirebaseFunctionsTest } from '../src/lifecycle';
-import { alerts } from 'firebase-functions/v2';
+import { alerts } from 'firebase-functions';
 import { wrapV2 } from '../src/v2';
 
 describe('main', () => {

--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 import fft = require('../../src/index');
 
 const cfToUpperCaseOnRequest = functions.https.onRequest((req, res) => {

--- a/spec/providers/scheduled.spec.ts
+++ b/spec/providers/scheduled.spec.ts
@@ -1,5 +1,5 @@
 import * as sinon from 'sinon';
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 import fft = require('../../src/index');
 import { WrappedScheduledFunction } from '../../src/main';
 

--- a/spec/v2.spec.ts
+++ b/spec/v2.spec.ts
@@ -35,7 +35,7 @@ import {
   eventarc,
   https,
   firestore,
-} from 'firebase-functions/v2';
+} from 'firebase-functions';
 import { defineString } from 'firebase-functions/params';
 import { makeDataSnapshot } from '../src/providers/database';
 import { makeDocumentSnapshot } from '../src/providers/firestore';

--- a/src/cloudevent/generate.ts
+++ b/src/cloudevent/generate.ts
@@ -3,14 +3,14 @@ import {
   CloudFunction,
   database,
   pubsub,
-} from 'firebase-functions/v2';
+} from 'firebase-functions';
 import {
   DocumentSnapshot,
   QueryDocumentSnapshot,
 } from 'firebase-admin/firestore';
 import { LIST_OF_MOCK_CLOUD_EVENT_PARTIALS } from './mocks/partials';
 import { DeepPartial } from './types';
-import { Change } from 'firebase-functions';
+import { Change } from 'firebase-functions/v1';
 import merge from 'ts-deepmerge';
 
 /**

--- a/src/cloudevent/mocks/alerts/alerts-on-alert-published.ts
+++ b/src/cloudevent/mocks/alerts/alerts-on-alert-published.ts
@@ -1,12 +1,12 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   APP_ID,
   getBaseCloudEvent,
   getEventType,
   PROJECT_ID,
 } from '../helpers';
-import { FirebaseAlertData, AlertEvent } from 'firebase-functions/v2/alerts';
+import { FirebaseAlertData, AlertEvent } from 'firebase-functions/alerts';
 
 export const alertsOnAlertPublished: MockCloudEventAbstractFactory<AlertEvent<
   FirebaseAlertData

--- a/src/cloudevent/mocks/alerts/app-distribution-on-new-tester-ios-device-published.ts
+++ b/src/cloudevent/mocks/alerts/app-distribution-on-new-tester-ios-device-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -9,7 +9,7 @@ import {
 import {
   AppDistributionEvent,
   NewTesterDevicePayload,
-} from 'firebase-functions/v2/alerts/appDistribution';
+} from 'firebase-functions/alerts/appDistribution';
 
 export const alertsAppDistributionOnNewTesterIosDevicePublished: MockCloudEventAbstractFactory<AppDistributionEvent<
   NewTesterDevicePayload

--- a/src/cloudevent/mocks/alerts/billing-on-plan-automated-update-published.ts
+++ b/src/cloudevent/mocks/alerts/billing-on-plan-automated-update-published.ts
@@ -1,10 +1,10 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+import { CloudFunction } from 'firebase-functions';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 import {
   BillingEvent,
   PlanAutomatedUpdatePayload,
-} from 'firebase-functions/v2/alerts/billing';
+} from 'firebase-functions/alerts/billing';
 import {
   getBaseCloudEvent,
   getEventFilters,

--- a/src/cloudevent/mocks/alerts/billing-on-plan-update-published.ts
+++ b/src/cloudevent/mocks/alerts/billing-on-plan-update-published.ts
@@ -1,10 +1,10 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+import { CloudFunction } from 'firebase-functions';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 import {
   BillingEvent,
   PlanUpdatePayload,
-} from 'firebase-functions/v2/alerts/billing';
+} from 'firebase-functions/alerts/billing';
 import {
   getBaseCloudEvent,
   getEventFilters,

--- a/src/cloudevent/mocks/alerts/crashlytics-on-new-anr-issue-published.ts
+++ b/src/cloudevent/mocks/alerts/crashlytics-on-new-anr-issue-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -9,8 +9,8 @@ import {
 import {
   CrashlyticsEvent,
   NewAnrIssuePayload,
-} from 'firebase-functions/v2/alerts/crashlytics';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+} from 'firebase-functions/alerts/crashlytics';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 
 export const alertsCrashlyticsOnNewAnrIssuePublished: MockCloudEventAbstractFactory<CrashlyticsEvent<
   NewAnrIssuePayload

--- a/src/cloudevent/mocks/alerts/crashlytics-on-new-fatal-issue-published.ts
+++ b/src/cloudevent/mocks/alerts/crashlytics-on-new-fatal-issue-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -9,8 +9,8 @@ import {
 import {
   CrashlyticsEvent,
   NewFatalIssuePayload,
-} from 'firebase-functions/v2/alerts/crashlytics';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+} from 'firebase-functions/alerts/crashlytics';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 
 export const alertsCrashlyticsOnNewFatalIssuePublished: MockCloudEventAbstractFactory<CrashlyticsEvent<
   NewFatalIssuePayload

--- a/src/cloudevent/mocks/alerts/crashlytics-on-new-nonfatal-issue-published.ts
+++ b/src/cloudevent/mocks/alerts/crashlytics-on-new-nonfatal-issue-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -9,8 +9,8 @@ import {
 import {
   CrashlyticsEvent,
   NewNonfatalIssuePayload,
-} from 'firebase-functions/v2/alerts/crashlytics';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+} from 'firebase-functions/alerts/crashlytics';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 
 export const alertsCrashlyticsOnNewNonfatalIssuePublished: MockCloudEventAbstractFactory<CrashlyticsEvent<
   NewNonfatalIssuePayload

--- a/src/cloudevent/mocks/alerts/crashlytics-on-regression-alert-published.ts
+++ b/src/cloudevent/mocks/alerts/crashlytics-on-regression-alert-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -9,8 +9,8 @@ import {
 import {
   CrashlyticsEvent,
   RegressionAlertPayload,
-} from 'firebase-functions/v2/alerts/crashlytics';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+} from 'firebase-functions/alerts/crashlytics';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 
 export const alertsCrashlyticsOnRegressionAlertPublished: MockCloudEventAbstractFactory<CrashlyticsEvent<
   RegressionAlertPayload

--- a/src/cloudevent/mocks/alerts/crashlytics-on-stability-digest-published.ts
+++ b/src/cloudevent/mocks/alerts/crashlytics-on-stability-digest-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -9,8 +9,8 @@ import {
 import {
   CrashlyticsEvent,
   StabilityDigestPayload,
-} from 'firebase-functions/v2/alerts/crashlytics';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+} from 'firebase-functions/alerts/crashlytics';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 
 export const alertsCrashlyticsOnStabilityDigestPublished: MockCloudEventAbstractFactory<CrashlyticsEvent<
   StabilityDigestPayload

--- a/src/cloudevent/mocks/alerts/crashlytics-on-velocity-alert-published.ts
+++ b/src/cloudevent/mocks/alerts/crashlytics-on-velocity-alert-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -9,8 +9,8 @@ import {
 import {
   CrashlyticsEvent,
   VelocityAlertPayload,
-} from 'firebase-functions/v2/alerts/crashlytics';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+} from 'firebase-functions/alerts/crashlytics';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 
 export const alertsCrashlyticsOnVelocityAlertPublished: MockCloudEventAbstractFactory<CrashlyticsEvent<
   VelocityAlertPayload

--- a/src/cloudevent/mocks/alerts/performance-on-threshold-alert-published.ts
+++ b/src/cloudevent/mocks/alerts/performance-on-threshold-alert-published.ts
@@ -1,9 +1,9 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction } from 'firebase-functions/v2';
+import { CloudFunction } from 'firebase-functions';
 import {
   PerformanceEvent,
   ThresholdAlertPayload,
-} from 'firebase-functions/v2/alerts/performance';
+} from 'firebase-functions/alerts/performance';
 import {
   getBaseCloudEvent,
   getEventFilters,
@@ -11,7 +11,7 @@ import {
   PROJECT_ID,
   APP_ID,
 } from '../helpers';
-import { FirebaseAlertData } from 'firebase-functions/v2/alerts';
+import { FirebaseAlertData } from 'firebase-functions/alerts';
 
 export const performanceThresholdOnThresholdAlertPublished: MockCloudEventAbstractFactory<PerformanceEvent<
   ThresholdAlertPayload

--- a/src/cloudevent/mocks/database/database-on-value-created.ts
+++ b/src/cloudevent/mocks/database/database-on-value-created.ts
@@ -1,5 +1,5 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, database } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, database } from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { getDatabaseSnapshotCloudEvent } from './helpers';
 

--- a/src/cloudevent/mocks/database/database-on-value-deleted.ts
+++ b/src/cloudevent/mocks/database/database-on-value-deleted.ts
@@ -1,5 +1,5 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, database } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, database } from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { getDatabaseSnapshotCloudEvent } from './helpers';
 

--- a/src/cloudevent/mocks/database/database-on-value-updated.ts
+++ b/src/cloudevent/mocks/database/database-on-value-updated.ts
@@ -1,7 +1,7 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, database } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, database } from 'firebase-functions';
 import { getEventType } from '../helpers';
-import { Change } from 'firebase-functions';
+import { Change } from 'firebase-functions/v1';
 import { getDatabaseChangeSnapshotCloudEvent } from './helpers';
 
 export const databaseOnValueUpdated: MockCloudEventAbstractFactory<database.DatabaseEvent<

--- a/src/cloudevent/mocks/database/database-on-value-written.ts
+++ b/src/cloudevent/mocks/database/database-on-value-written.ts
@@ -1,7 +1,7 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, database } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, database } from 'firebase-functions';
 import { getEventType } from '../helpers';
-import { Change } from 'firebase-functions';
+import { Change } from 'firebase-functions/v1';
 import { getDatabaseChangeSnapshotCloudEvent } from './helpers';
 
 export const databaseOnValueWritten: MockCloudEventAbstractFactory<database.DatabaseEvent<

--- a/src/cloudevent/mocks/database/helpers.ts
+++ b/src/cloudevent/mocks/database/helpers.ts
@@ -1,4 +1,4 @@
-import { CloudFunction, database } from 'firebase-functions/v2';
+import { CloudFunction, database } from 'firebase-functions';
 import { DeepPartial } from '../../types';
 import {
   exampleDataSnapshot,
@@ -9,7 +9,7 @@ import {
   getBaseCloudEvent,
   extractRef,
 } from '../helpers';
-import { Change } from 'firebase-functions';
+import { Change } from 'firebase-functions/v1';
 import { makeDataSnapshot } from '../../../providers/database';
 
 type ChangeLike = {

--- a/src/cloudevent/mocks/eventarc/eventarc-on-custom-event-published.ts
+++ b/src/cloudevent/mocks/eventarc/eventarc-on-custom-event-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction } from 'firebase-functions';
 import { getBaseCloudEvent } from '../helpers';
 
 export const eventarcOnCustomEventPublished: MockCloudEventAbstractFactory<any> = {

--- a/src/cloudevent/mocks/firestore/firestore-on-document-created-with-auth-context.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-created-with-auth-context.ts
@@ -1,5 +1,5 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, firestore } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, firestore } from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { QueryDocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotCloudEventWithAuthContext } from './helpers';

--- a/src/cloudevent/mocks/firestore/firestore-on-document-created.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-created.ts
@@ -1,5 +1,5 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, firestore } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, firestore } from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { QueryDocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotCloudEvent } from './helpers';

--- a/src/cloudevent/mocks/firestore/firestore-on-document-deleted-with-auth-context.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-deleted-with-auth-context.ts
@@ -1,5 +1,5 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, firestore } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, firestore } from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { QueryDocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotCloudEventWithAuthContext } from './helpers';

--- a/src/cloudevent/mocks/firestore/firestore-on-document-deleted.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-deleted.ts
@@ -1,5 +1,5 @@
 import { MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, firestore } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, firestore } from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { QueryDocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotCloudEvent } from './helpers';

--- a/src/cloudevent/mocks/firestore/firestore-on-document-updated-with-auth-context.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-updated-with-auth-context.ts
@@ -4,7 +4,7 @@ import {
   CloudEvent,
   CloudFunction,
   firestore,
-} from 'firebase-functions/v2';
+} from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { QueryDocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotChangeCloudEventWithAuthContext } from './helpers';

--- a/src/cloudevent/mocks/firestore/firestore-on-document-updated.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-updated.ts
@@ -4,7 +4,7 @@ import {
   CloudEvent,
   CloudFunction,
   firestore,
-} from 'firebase-functions/v2';
+} from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { QueryDocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotChangeCloudEvent } from './helpers';

--- a/src/cloudevent/mocks/firestore/firestore-on-document-written-with-auth-context.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-written-with-auth-context.ts
@@ -4,7 +4,7 @@ import {
   CloudEvent,
   CloudFunction,
   firestore,
-} from 'firebase-functions/v2';
+} from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { DocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotChangeCloudEventWithAuthContext } from './helpers';

--- a/src/cloudevent/mocks/firestore/firestore-on-document-written.ts
+++ b/src/cloudevent/mocks/firestore/firestore-on-document-written.ts
@@ -4,7 +4,7 @@ import {
   CloudEvent,
   CloudFunction,
   firestore,
-} from 'firebase-functions/v2';
+} from 'firebase-functions';
 import { getEventType } from '../helpers';
 import { DocumentSnapshot } from 'firebase-admin/firestore';
 import { getDocumentSnapshotChangeCloudEvent } from './helpers';

--- a/src/cloudevent/mocks/firestore/helpers.ts
+++ b/src/cloudevent/mocks/firestore/helpers.ts
@@ -1,5 +1,5 @@
 import { DocumentSnapshot } from 'firebase-admin/firestore';
-import { Change, CloudFunction, firestore } from 'firebase-functions/v2';
+import { Change, CloudFunction, firestore } from 'firebase-functions';
 import {
   exampleDocumentSnapshot,
   exampleDocumentSnapshotChange,

--- a/src/cloudevent/mocks/helpers.ts
+++ b/src/cloudevent/mocks/helpers.ts
@@ -1,5 +1,5 @@
-import * as v1 from 'firebase-functions';
-import * as v2 from 'firebase-functions/v2';
+import * as v1 from 'firebase-functions/v1';
+import * as v2 from 'firebase-functions';
 import { Expression } from 'firebase-functions/params';
 
 export const APP_ID = '__APP_ID__';

--- a/src/cloudevent/mocks/pubsub/pubsub-on-message-published.ts
+++ b/src/cloudevent/mocks/pubsub/pubsub-on-message-published.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudEvent, CloudFunction, pubsub } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction, pubsub } from 'firebase-functions';
 import {
   getBaseCloudEvent,
   getEventFilters,

--- a/src/cloudevent/mocks/remoteconfig/remote-config-on-config-updated.ts
+++ b/src/cloudevent/mocks/remoteconfig/remote-config-on-config-updated.ts
@@ -1,6 +1,6 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction, CloudEvent } from 'firebase-functions/v2';
-import { ConfigUpdateData } from 'firebase-functions/v2/remoteConfig';
+import { CloudFunction, CloudEvent } from 'firebase-functions';
+import { ConfigUpdateData } from 'firebase-functions/remoteConfig';
 import { getBaseCloudEvent, getEventType, PROJECT_ID } from '../helpers';
 
 export const remoteConfigOnConfigUpdated: MockCloudEventAbstractFactory<CloudEvent<

--- a/src/cloudevent/mocks/storage/index.ts
+++ b/src/cloudevent/mocks/storage/index.ts
@@ -1,6 +1,6 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction, CloudEvent } from 'firebase-functions/v2';
-import { StorageEvent } from 'firebase-functions/v2/storage';
+import { CloudFunction, CloudEvent } from 'firebase-functions';
+import { StorageEvent } from 'firebase-functions/storage';
 import {
   FILENAME,
   resolveStringExpression,

--- a/src/cloudevent/mocks/storage/storage-data.ts
+++ b/src/cloudevent/mocks/storage/storage-data.ts
@@ -1,4 +1,4 @@
-import { storage } from 'firebase-functions/v2';
+import { storage } from 'firebase-functions';
 import { FILENAME } from '../helpers';
 
 /** Storage Data */

--- a/src/cloudevent/mocks/testlab/test-lab-on-test-matrix-completed.ts
+++ b/src/cloudevent/mocks/testlab/test-lab-on-test-matrix-completed.ts
@@ -1,6 +1,6 @@
 import { DeepPartial, MockCloudEventAbstractFactory } from '../../types';
-import { CloudFunction, CloudEvent } from 'firebase-functions/v2';
-import { TestMatrixCompletedData } from 'firebase-functions/v2/testLab';
+import { CloudFunction, CloudEvent } from 'firebase-functions';
+import { TestMatrixCompletedData } from 'firebase-functions/testLab';
 import { getBaseCloudEvent, getEventType, PROJECT_ID } from '../helpers';
 
 export const testLabOnTestMatrixCompleted: MockCloudEventAbstractFactory<CloudEvent<

--- a/src/cloudevent/types.ts
+++ b/src/cloudevent/types.ts
@@ -1,4 +1,4 @@
-import { CloudEvent, CloudFunction } from 'firebase-functions/v2';
+import { CloudEvent, CloudFunction } from 'firebase-functions';
 
 export type DeepPartial<T extends object> = {
   [Key in keyof T]?: T[Key] extends object ? DeepPartial<T[Key]> : T[Key];

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,17 +24,17 @@ import {
   CloudFunction as CloudFunctionV1,
   HttpsFunction,
   Runnable,
-} from 'firebase-functions';
+} from 'firebase-functions/v1';
 
 import {
   CloudFunction as CloudFunctionV2,
   CloudEvent,
-} from 'firebase-functions/v2';
+} from 'firebase-functions';
 
 import {
   CallableFunction,
   HttpsFunction as HttpsFunctionV2,
-} from 'firebase-functions/v2/https';
+} from 'firebase-functions/https';
 
 import { wrapV1, WrappedFunction, WrappedScheduledFunction } from './v1';
 

--- a/src/providers/analytics.ts
+++ b/src/providers/analytics.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { analytics } from 'firebase-functions';
+import { analytics } from 'firebase-functions/v1';
 
 /** Create an AnalyticsEvent */
 export function makeAnalyticsEvent(

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { auth } from 'firebase-functions';
+import { auth } from 'firebase-functions/v1';
 
 /** Create a UserRecord. */
 export function makeUserRecord(

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { database, Change } from 'firebase-functions';
+import { database, Change } from 'firebase-functions/v1';
 import { app } from 'firebase-admin';
 
 import { testApp } from '../app';

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Change } from 'firebase-functions';
+import { Change } from 'firebase-functions/v1';
 import { firestore, app } from 'firebase-admin';
 import { has, get, isEmpty, isPlainObject, mapValues } from 'lodash';
 import { inspect } from 'util';

--- a/src/providers/pubsub.ts
+++ b/src/providers/pubsub.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { pubsub } from 'firebase-functions';
+import { pubsub } from 'firebase-functions/v1';
 
 /** Create a Message from a JSON object. */
 export function makeMessage(

--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { storage } from 'firebase-functions';
+import { storage } from 'firebase-functions/v1';
 
 /** Create an ObjectMetadata */
 export function makeObjectMetadata(

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -34,7 +34,7 @@ import {
   Runnable,
   // @ts-ignore
   resetCache,
-} from 'firebase-functions';
+} from 'firebase-functions/v1';
 import { Expression } from 'firebase-functions/params';
 import {
   getEventFilters,

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { CloudFunction, CloudEvent } from 'firebase-functions/v2';
-import { CallableFunction, CallableRequest } from 'firebase-functions/v2/https';
+import { CloudFunction, CloudEvent } from 'firebase-functions';
+import { CallableFunction, CallableRequest } from 'firebase-functions/https';
 
 import { generateCombinedCloudEvent } from './cloudevent/generate';
 import { DeepPartial } from './cloudevent/types';


### PR DESCRIPTION
### Description

Attempting to resolve https://github.com/firebase/firebase-functions-test/issues/241

My process was:

1. Search for `'firebase-functions'`, and add `/v1` to all 16 instances
2. Search for `'firebase-functions/v2`, and remove `/v2` from all 64 instances (note the lack of closing single quote to catch subdirectories)
3. I noticed 3 instances of `firebase-functions/params`, but there appears to be no `/v1/` version for that. I left it alone.

Tests are passing. I may have gotten things wrong, but hopefully this grunt work gets maintainers closer to an update.