### PR TITLE
Peer dependency for firebase-admin 13 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.2.5"
   },
   "peerDependencies": {
-    "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+    "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
     "firebase-functions": ">=4.9.0",
     "jest": ">=28.0.0"
   },


### PR DESCRIPTION
### Description

Resolve [package not compatible with firebase-admin 13](https://github.com/firebase/firebase-functions-test/issues/246)

Previously, firebase-admin 13 was not supported in peer dependencies. Original peer deps: 

```
"peerDependencies": {
    "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
    "firebase-functions": ">=4.9.0",
    "jest": ">=28.0.0"
  },
```

firebase-functions-test should work with latest version of firebase-admin. Tests passing.
