### PR TITLE
Failing test case for calling DataSnapshot methods with null values

### DIFF
--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -31,6 +31,7 @@ describe('providers/database', () => {
 
     expect(snapshot.val()).to.deep.equal(null);
     expect(snapshot.ref.key).to.equal('path');
+    expect(snapshot.child('foo').val()).to.deep.equal(null);
   });
 
   it('should use the default test apps databaseURL if no instance is specified in makeDataSnapshot', async () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

If you've created a `DataSnapshot` with a `null` value, you should be able to call methods on that object.
Will be fixed with an incoming upstream fix in [`firebase-functions`](https://github.com/firebase/firebase-functions).

### Code sample

See commit