### PR TITLE
fixing git credential issue in publish

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -58,7 +58,8 @@ echo "Moved to temporary directory."
 
 echo "Cloning repository..."
 if [[ -n "$GITHUB_TOKEN" ]]; then
-  git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY_ORG}/${REPOSITORY_NAME}.git"
+  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+  git clone "https://github.com/${REPOSITORY_ORG}/${REPOSITORY_NAME}.git"
 else
   git clone "git@github.com:${REPOSITORY_ORG}/${REPOSITORY_NAME}.git"
 fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -57,7 +57,11 @@ cd "${TEMPDIR}"
 echo "Moved to temporary directory."
 
 echo "Cloning repository..."
-git clone "git@github.com:${REPOSITORY_ORG}/${REPOSITORY_NAME}.git"
+if [[ -n "$GITHUB_TOKEN" ]]; then
+  git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY_ORG}/${REPOSITORY_NAME}.git"
+else
+  git clone "git@github.com:${REPOSITORY_ORG}/${REPOSITORY_NAME}.git"
+fi
 cd "${REPOSITORY_NAME}"
 echo "Cloned repository."
 


### PR DESCRIPTION
Detects if the GITHUB_TOKEN environment variable is provided.
If available, clones the repository over HTTPS using the token (x-access-token), bypassing the obsolete SSH clone command.