### PR TITLE
fix: tighten v2 wrapper event typing

### DIFF
--- a/spec/v2.spec.ts
+++ b/spec/v2.spec.ts
@@ -49,7 +49,10 @@ describe('v2', () => {
     it('should restrict V2 wrapper arguments to CloudEvent partials', () => {
       const cloudFn = firestore.onDocumentWritten('foo/bar/baz', handler);
       const cloudFnWrap = wrapV2(cloudFn);
-      const before = makeDocumentSnapshot({ snapshot: 'before' }, 'foo/bar/baz');
+      const before = makeDocumentSnapshot(
+        { snapshot: 'before' },
+        'foo/bar/baz'
+      );
       const after = makeDocumentSnapshot({ snapshot: 'after' }, 'foo/bar/baz');
       const change = makeChange(before, after);
 

--- a/spec/v2.spec.ts
+++ b/spec/v2.spec.ts
@@ -46,7 +46,7 @@ describe('v2', () => {
   describe('#wrapV2', () => {
     const handler = (cloudEvent) => ({ cloudEvent });
 
-    function assertWrappedV2FunctionTypes() {
+    it('should restrict V2 wrapper arguments to CloudEvent partials', () => {
       const cloudFn = firestore.onDocumentWritten('foo/bar/baz', handler);
       const cloudFnWrap = wrapV2(cloudFn);
       const before = makeDocumentSnapshot({ snapshot: 'before' }, 'foo/bar/baz');
@@ -56,7 +56,7 @@ describe('v2', () => {
       cloudFnWrap({ data: change });
       // @ts-expect-error V2 wrappers accept CloudEvent partials, not raw event data.
       cloudFnWrap(change);
-    }
+    });
 
     describe('alerts', () => {
       describe('alerts.onAlertPublished()', () => {

--- a/spec/v2.spec.ts
+++ b/spec/v2.spec.ts
@@ -39,11 +39,24 @@ import {
 import { defineString } from 'firebase-functions/params';
 import { makeDataSnapshot } from '../src/providers/database';
 import { makeDocumentSnapshot } from '../src/providers/firestore';
+import { makeChange } from '../src/v1';
 import { inspect } from 'util';
 
 describe('v2', () => {
   describe('#wrapV2', () => {
     const handler = (cloudEvent) => ({ cloudEvent });
+
+    function assertWrappedV2FunctionTypes() {
+      const cloudFn = firestore.onDocumentWritten('foo/bar/baz', handler);
+      const cloudFnWrap = wrapV2(cloudFn);
+      const before = makeDocumentSnapshot({ snapshot: 'before' }, 'foo/bar/baz');
+      const after = makeDocumentSnapshot({ snapshot: 'after' }, 'foo/bar/baz');
+      const change = makeChange(before, after);
+
+      cloudFnWrap({ data: change });
+      // @ts-expect-error V2 wrappers accept CloudEvent partials, not raw event data.
+      cloudFnWrap(change);
+    }
 
     describe('alerts', () => {
       describe('alerts.onAlertPublished()', () => {

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -27,11 +27,17 @@ import { generateCombinedCloudEvent } from './cloudevent/generate';
 import { DeepPartial } from './cloudevent/types';
 import * as express from 'express';
 
+type WrappedV2CloudEventPartial<T extends CloudEvent<unknown>> = DeepPartial<
+  Omit<T, 'data'>
+> & {
+  data?: T['data'] | object;
+};
+
 /** A function that can be called with test data and optional override values for {@link CloudEvent}
  * It will subsequently invoke the cloud function it wraps with the provided {@link CloudEvent}
  */
 export type WrappedV2Function<T extends CloudEvent<unknown>> = (
-  cloudEventPartial?: DeepPartial<T | object>
+  cloudEventPartial?: WrappedV2CloudEventPartial<T>
 ) => any | Promise<any>;
 
 export type WrappedV2CallableFunction<T> = (


### PR DESCRIPTION
## Summary

Touches on https://github.com/firebase/firebase-functions-test/issues/205

- Tighten `WrappedV2Function` so wrapper arguments must keep CloudEvent shape.
- Preserve flexible `data` overrides for generated mock payloads and JSON test data.
- Add a compile-time regression check showing `wrapped({ data: change })` is valid while raw `wrapped(change)` is rejected.

## Why

V2 wrapped functions accept CloudEvent partials, but the previous `DeepPartial<T | object>` type let callers pass raw event data. For Firestore change triggers, that makes `wrapped(change)` compile even though runtime code reads `cloudEventPartial.data` and falls back to example data.

## Validation

- `npm run pretest`
- `npm run lint`
- `env -u GOOGLE_APPLICATION_CREDENTIALS npm test`