### PR TITLE
Chore: update CI to run on Node 24, drop Node 20 from CI, maintain Node 20 engine support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.x
           - 22.x
+          - 24.x
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -36,8 +36,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.x
           - 22.x
+          - 24.x
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- chore: drop support for Node 18 and below (minimum supported version is now Node 20)

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": ">=28.0.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.0.0"
   },
   "typings": "lib/index.d.ts"
 }


### PR DESCRIPTION
Our CI is dropping support for Node 20 imminently so updating ahead of that.

Given that Node 18 runtime in decommissioned for Google Cloud Functions updating our supported runtime to 20.