### PR TITLE
chore(security): bump node engine requirement to >=22.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": ">=28.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "typings": "lib/index.d.ts"
 }


### PR DESCRIPTION
Bumps Node engine requirement in `package.json` to `>=22.0.0` to target a supported Node runtime.