### PR TITLE
docs: clarify makeMessage is a v1-only helper

### DIFF
--- a/src/providers/pubsub.ts
+++ b/src/providers/pubsub.ts
@@ -42,7 +42,10 @@ export function makeMessage(
  * Create a Message from a base-64 encoded string.
  *
  * Note: this helper is for v1 `functions.pubsub.topic(...).onPublish` functions
- * only. See the overload above for testing v2 `onMessagePublished` functions.
+ * only. Do not pass its result to `wrapV2`; for v2 `onMessagePublished`
+ * functions, pass a plain CloudEvent partial instead, e.g.
+ * `wrapV2(fn)({ data: { message: { json: { hello: 'world' } } } })` or
+ * `wrapV2(fn)({ data: { message: { data: base64String } } })`.
  */
 export function makeMessage(
   /** Base-64 encoded message string. */

--- a/src/providers/pubsub.ts
+++ b/src/providers/pubsub.ts
@@ -22,7 +22,15 @@
 
 import { pubsub } from 'firebase-functions/v1';
 
-/** Create a Message from a JSON object. */
+/**
+ * Create a Message from a JSON object.
+ *
+ * Note: this helper is for v1 `functions.pubsub.topic(...).onPublish` functions
+ * only. Do not pass its result to `wrapV2`; for v2 `onMessagePublished`
+ * functions, pass a plain CloudEvent partial instead, e.g.
+ * `wrapV2(fn)({ data: { message: { json: { hello: 'world' } } } })` or
+ * `wrapV2(fn)({ data: { message: { data: base64String } } })`.
+ */
 export function makeMessage(
   /** Content of message. */
   json: { [key: string]: any },
@@ -30,7 +38,12 @@ export function makeMessage(
   attributes?: { [key: string]: string }
 ): pubsub.Message;
 
-/** Create a Message from a base-64 encoded string. */
+/**
+ * Create a Message from a base-64 encoded string.
+ *
+ * Note: this helper is for v1 `functions.pubsub.topic(...).onPublish` functions
+ * only. See the overload above for testing v2 `onMessagePublished` functions.
+ */
 export function makeMessage(
   /** Base-64 encoded message string. */
   encodedString: string,


### PR DESCRIPTION
### Description

`makeMessage` builds a v1 `pubsub.Message`, but nothing in its docs says so, and passing its result to `wrapV2` fails in a confusing way: the v2 mock factory reads the message's `json` getter, which eagerly runs `JSON.parse(base64Decode(data))` and throws on non-JSON payloads before the handler runs (see #235 for the full diagnosis).

This adds jsdoc to both `makeMessage` overloads marking the helper as v1-only and showing the CloudEvent-partial patterns to use with `wrapV2` instead:

```ts
wrapV2(fn)({ data: { message: { json: { hello: 'world' } } } });
wrapV2(fn)({ data: { message: { data: base64String } } });
```

Docs-only change, no runtime behavior affected.

Fixes #235