### PR TITLE
Add firebase-functions v7 CI leg; make mockConfig() throw on v7+

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
   - pull_request
   - push
 
+permissions:
+  contents: read
+
 env:
   CI: true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,9 @@ jobs:
         node-version:
           - 22.x
           - 24.x
+        firebase-functions:
+          - pinned
+          - '7'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -30,7 +33,22 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format
-      - run: npm run test
+      - name: Run tests (pinned firebase-functions)
+        if: matrix.firebase-functions == 'pinned'
+        run: npm run test
+      # Specs do not compile against firebase-functions v7 typings, so
+      # compile against the pinned version, swap in v7, and run the
+      # compiled output. This mirrors how users hit version drift: their
+      # compiled code running against a newer firebase-functions.
+      - name: Compile specs against pinned firebase-functions
+        if: matrix.firebase-functions == '7'
+        run: npx tsc
+      - name: Swap in firebase-functions@7
+        if: matrix.firebase-functions == '7'
+        run: npm install --no-save firebase-functions@^7
+      - name: Run tests (firebase-functions@7)
+        if: matrix.firebase-functions == '7'
+        run: npx mocha .tmp/spec/index.spec.js
   integration:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,13 +19,13 @@ jobs:
           - pinned
           - '7'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache npm
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
@@ -61,13 +61,13 @@ jobs:
           - 22.x
           - 24.x
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache npm
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,8 +31,12 @@ jobs:
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
 
       - run: npm ci
-      - run: npm run lint
-      - run: npm run format
+      - name: Lint
+        if: matrix.firebase-functions == 'pinned'
+        run: npm run lint
+      - name: Format
+        if: matrix.firebase-functions == 'pinned'
+        run: npm run format
       - name: Run tests (pinned firebase-functions)
         if: matrix.firebase-functions == 'pinned'
         run: npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - chore: drop support for Node 18 and below (minimum supported version is now Node 20)
+- fix: mockConfig() now throws a clear migration error when firebase-functions v7+ is installed, since functions.config() was removed upstream (#334)

--- a/spec/lifecycle.spec.ts
+++ b/spec/lifecycle.spec.ts
@@ -24,7 +24,19 @@ import { expect } from 'chai';
 
 import { FirebaseFunctionsTest } from '../src/lifecycle';
 import { mockConfig } from '../src/main';
+import { _firebaseFunctionsMajorVersion } from '../src/v1';
 import { afterEach } from 'mocha';
+
+// mockConfig() throws on firebase-functions v7+ because functions.config()
+// was removed. These tests only care about CLOUD_RUNTIME_CONFIG being
+// restored by cleanup(), so set the variable directly on v7+.
+function setRuntimeConfig(conf: { [key: string]: { [key: string]: any } }) {
+  if ((_firebaseFunctionsMajorVersion() ?? 0) >= 7) {
+    process.env.CLOUD_RUNTIME_CONFIG = JSON.stringify(conf);
+  } else {
+    mockConfig(conf);
+  }
+}
 
 describe('lifecycle', () => {
   describe('#init', () => {
@@ -87,7 +99,7 @@ describe('lifecycle', () => {
     it('deletes all the env variables if they did not previously exist', () => {
       let test = new FirebaseFunctionsTest();
       test.init();
-      mockConfig({ foo: { bar: 'faz ' } });
+      setRuntimeConfig({ foo: { bar: 'faz ' } });
       test.cleanup();
       expect(process.env.FIREBASE_CONFIG).to.be.undefined;
       expect(process.env.GCLOUD_PROJECT).to.be.undefined;
@@ -103,7 +115,7 @@ describe('lifecycle', () => {
       let test = new FirebaseFunctionsTest();
 
       test.init();
-      mockConfig({ foo: { bar: 'faz ' } });
+      setRuntimeConfig({ foo: { bar: 'faz ' } });
       test.cleanup();
 
       expect(process.env.FIREBASE_CONFIG).to.equal('oldFb');

--- a/spec/lifecycle.spec.ts
+++ b/spec/lifecycle.spec.ts
@@ -24,14 +24,14 @@ import { expect } from 'chai';
 
 import { FirebaseFunctionsTest } from '../src/lifecycle';
 import { mockConfig } from '../src/main';
-import { _firebaseFunctionsMajorVersion } from '../src/v1';
+import { _isConfigRemoved } from '../src/v1';
 import { afterEach } from 'mocha';
 
 // mockConfig() throws on firebase-functions v7+ because functions.config()
 // was removed. These tests only care about CLOUD_RUNTIME_CONFIG being
 // restored by cleanup(), so set the variable directly on v7+.
 function setRuntimeConfig(conf: { [key: string]: { [key: string]: any } }) {
-  if ((_firebaseFunctionsMajorVersion() ?? 0) >= 7) {
+  if (_isConfigRemoved()) {
     process.env.CLOUD_RUNTIME_CONFIG = JSON.stringify(conf);
   } else {
     mockConfig(conf);

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -25,11 +25,7 @@ import * as functions from 'firebase-functions/v1';
 import { set } from 'lodash';
 
 import { mockConfig, makeChange, wrap } from '../src/main';
-import {
-  _makeResourceName,
-  _extractParams,
-  _firebaseFunctionsMajorVersion,
-} from '../src/v1';
+import { _makeResourceName, _extractParams, _isConfigRemoved } from '../src/v1';
 import { features } from '../src/features';
 import { FirebaseFunctionsTest } from '../src/lifecycle';
 import { alerts } from 'firebase-functions/v2';
@@ -333,7 +329,7 @@ describe('main', () => {
       delete process.env.CLOUD_RUNTIME_CONFIG;
     });
 
-    if ((_firebaseFunctionsMajorVersion() ?? 0) >= 7) {
+    if (_isConfigRemoved()) {
       // functions.config() was removed in firebase-functions v7, so
       // mockConfig() must fail loudly with migration guidance.
       it('should throw explaining that functions.config() was removed', () => {

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -25,7 +25,11 @@ import * as functions from 'firebase-functions/v1';
 import { set } from 'lodash';
 
 import { mockConfig, makeChange, wrap } from '../src/main';
-import { _makeResourceName, _extractParams } from '../src/v1';
+import {
+  _makeResourceName,
+  _extractParams,
+  _firebaseFunctionsMajorVersion,
+} from '../src/v1';
 import { features } from '../src/features';
 import { FirebaseFunctionsTest } from '../src/lifecycle';
 import { alerts } from 'firebase-functions/v2';
@@ -329,17 +333,32 @@ describe('main', () => {
       delete process.env.CLOUD_RUNTIME_CONFIG;
     });
 
-    it('should mock functions.config()', () => {
-      mockConfig(config);
-      expect(functions.config()).to.deep.equal(config);
-    });
+    if ((_firebaseFunctionsMajorVersion() ?? 0) >= 7) {
+      // functions.config() was removed in firebase-functions v7, so
+      // mockConfig() must fail loudly with migration guidance.
+      it('should throw explaining that functions.config() was removed', () => {
+        expect(() => mockConfig(config)).to.throw(
+          'mockConfig() is not supported with firebase-functions v7+'
+        );
+      });
 
-    it('should purge singleton config object when it is present', () => {
-      mockConfig(config);
-      config.foo = { baz: 'qux' };
-      mockConfig(config);
+      it('should not set CLOUD_RUNTIME_CONFIG when throwing', () => {
+        expect(() => mockConfig(config)).to.throw();
+        expect(process.env.CLOUD_RUNTIME_CONFIG).to.be.undefined;
+      });
+    } else {
+      it('should mock functions.config()', () => {
+        mockConfig(config);
+        expect(functions.config()).to.deep.equal(config);
+      });
 
-      expect(functions.config()).to.deep.equal(config);
-    });
+      it('should purge singleton config object when it is present', () => {
+        mockConfig(config);
+        config.foo = { baz: 'qux' };
+        mockConfig(config);
+
+        expect(functions.config()).to.deep.equal(config);
+      });
+    }
   });
 });

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -391,7 +391,10 @@ export function _firebaseFunctionsMajorVersion(): number | undefined {
           pkg.name === 'firebase-functions' &&
           typeof pkg.version === 'string'
         ) {
-          return Number(pkg.version.split('.')[0]);
+          const major = parseInt(pkg.version.split('.')[0], 10);
+          if (!Number.isNaN(major)) {
+            return major;
+          }
         }
       }
       dir = path.dirname(dir);
@@ -405,16 +408,25 @@ export function _firebaseFunctionsMajorVersion(): number | undefined {
 /**
  * Returns true if the installed firebase-functions no longer supports
  * `functions.config()` (removed in v7).
+ * Exported for internal testing purposes only.
+ * @internal
  */
-function isConfigRemoved(): boolean {
+export function _isConfigRemoved(): boolean {
+  if (typeof config !== 'function') {
+    return true;
+  }
   const major = _firebaseFunctionsMajorVersion();
   if (major !== undefined) {
     return major >= 7;
   }
   // Fallback: feature-detect on the v1 entry point. In v7+, config()
   // throws unconditionally; in v4-v6 it parses CLOUD_RUNTIME_CONFIG.
+  // K_CONFIGURATION must be cleared for the probe, since v4-v6's config()
+  // also throws unconditionally when it is set (GCFv2 detection).
   const previous = process.env.CLOUD_RUNTIME_CONFIG;
+  const previousKConfiguration = process.env.K_CONFIGURATION;
   process.env.CLOUD_RUNTIME_CONFIG = '{}';
+  delete process.env.K_CONFIGURATION;
   try {
     config();
     return false;
@@ -426,12 +438,17 @@ function isConfigRemoved(): boolean {
     } else {
       process.env.CLOUD_RUNTIME_CONFIG = previous;
     }
+    if (previousKConfiguration === undefined) {
+      delete process.env.K_CONFIGURATION;
+    } else {
+      process.env.K_CONFIGURATION = previousKConfiguration;
+    }
   }
 }
 
 /** Mock values returned by `functions.config()`. */
 export function mockConfig(conf: { [key: string]: { [key: string]: any } }) {
-  if (isConfigRemoved()) {
+  if (_isConfigRemoved()) {
     throw new Error(
       'mockConfig() is not supported with firebase-functions v7+ because ' +
         'functions.config() was removed. Migrate to environment parameters ' +

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -20,6 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { has, merge, random, get } from 'lodash';
 
 import {
@@ -369,8 +372,72 @@ export function makeChange<T>(before: T, after: T): Change<T> {
   return Change.fromObjects(before, after);
 }
 
+/**
+ * Detects the major version of the installed firebase-functions package.
+ * Exported for internal testing purposes only.
+ * @internal
+ */
+export function _firebaseFunctionsMajorVersion(): number | undefined {
+  try {
+    // `firebase-functions/package.json` is not exposed by the package's
+    // exports map, so resolve the main entry point and walk up to the
+    // package root instead.
+    let dir = path.dirname(require.resolve('firebase-functions'));
+    while (dir !== path.dirname(dir)) {
+      const pkgPath = path.join(dir, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        if (
+          pkg.name === 'firebase-functions' &&
+          typeof pkg.version === 'string'
+        ) {
+          return Number(pkg.version.split('.')[0]);
+        }
+      }
+      dir = path.dirname(dir);
+    }
+  } catch (e) {
+    // Fall through to feature detection.
+  }
+  return undefined;
+}
+
+/**
+ * Returns true if the installed firebase-functions no longer supports
+ * `functions.config()` (removed in v7).
+ */
+function isConfigRemoved(): boolean {
+  const major = _firebaseFunctionsMajorVersion();
+  if (major !== undefined) {
+    return major >= 7;
+  }
+  // Fallback: feature-detect on the v1 entry point. In v7+, config()
+  // throws unconditionally; in v4-v6 it parses CLOUD_RUNTIME_CONFIG.
+  const previous = process.env.CLOUD_RUNTIME_CONFIG;
+  process.env.CLOUD_RUNTIME_CONFIG = '{}';
+  try {
+    config();
+    return false;
+  } catch (e) {
+    return true;
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CLOUD_RUNTIME_CONFIG;
+    } else {
+      process.env.CLOUD_RUNTIME_CONFIG = previous;
+    }
+  }
+}
+
 /** Mock values returned by `functions.config()`. */
 export function mockConfig(conf: { [key: string]: { [key: string]: any } }) {
+  if (isConfigRemoved()) {
+    throw new Error(
+      'mockConfig() is not supported with firebase-functions v7+ because ' +
+        'functions.config() was removed. Migrate to environment parameters ' +
+        'using the params module.'
+    );
+  }
   if (resetCache) {
     resetCache();
   }

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -405,13 +405,23 @@ export function _firebaseFunctionsMajorVersion(): number | undefined {
   return undefined;
 }
 
+let isConfigRemovedCache: boolean | undefined;
+
 /**
  * Returns true if the installed firebase-functions no longer supports
- * `functions.config()` (removed in v7).
+ * `functions.config()` (removed in v7). The result is cached, since the
+ * installed version cannot change within a process.
  * Exported for internal testing purposes only.
  * @internal
  */
 export function _isConfigRemoved(): boolean {
+  if (isConfigRemovedCache === undefined) {
+    isConfigRemovedCache = detectConfigRemoved();
+  }
+  return isConfigRemovedCache;
+}
+
+function detectConfigRemoved(): boolean {
   if (typeof config !== 'function') {
     return true;
   }


### PR DESCRIPTION
### Description

Refs #333 - implements the first two parts of the plan discussed there (the `latest` canary job is a follow-up and is intentionally not in this PR, so this does not close the issue).

**1. `mockConfig()` now throws on firebase-functions v7+ (behavior change)**

`functions.config()` was removed in firebase-functions v7 (it throws at runtime and is typed `never`). Previously `mockConfig()` would silently "succeed" on a v7 install while every subsequent `config()` read threw - a confusing trap. `mockConfig()` now detects the installed firebase-functions major version and fails at the mock site with migration guidance:

> mockConfig() is not supported with firebase-functions v7+ because functions.config() was removed. Migrate to environment parameters using the params module.

Detection resolves the installed `firebase-functions` entry point and walks up to its `package.json` to read the version (the package's exports map does not expose `./package.json`, on v4 or v7, so a plain `require('firebase-functions/package.json')` does not work). If the version cannot be determined, it falls back to feature-detecting `config()` on the v1 entry point.

Behavior on v4-v6 installs is unchanged.

**2. CI matrix: unit tests run against both pinned firebase-functions and v7**

The unit job gains a `firebase-functions: [pinned, '7']` matrix dimension. The `pinned` leg is exactly today's flow. The `7` leg compiles the specs against the pinned devDependency, swaps in `firebase-functions@^7` with `npm install --no-save`, and runs mocha on the already-compiled output. Compile-then-swap is needed because the specs do not compile against v6/v7 typings (nested `@types/express` lib-check conflict, plus `config` typed `never`), and it mirrors how users actually hit version drift (#310): their compiled code running against a newer firebase-functions.

The `#mockConfig` specs are version-aware: on the pinned leg they assert the existing mocking behavior; on the v7 leg they assert the new error (and that `CLOUD_RUNTIME_CONFIG` is left untouched). The two lifecycle env-restore tests seed `CLOUD_RUNTIME_CONFIG` directly on v7+ since their subject is `cleanup()`, not `mockConfig()`. Nothing is skipped on either leg.

Both legs are meant to be required checks - they target pinned majors, not floating `latest`, so they cannot go red from an unrelated upstream release. A scheduled non-blocking canary against `firebase-functions@latest` is the remaining part of #333.

Verified locally on Node 22:
- pinned (4.9.0): `npm ci && npm test` - 119 passing, 0 failing
- v7 (7.2.5): `npx tsc`, `npm install --no-save firebase-functions@^7`, `npx mocha .tmp/spec/index.spec.js` - 119 passing, 0 failing (v7 mockConfig assertions confirmed running), lint clean

### Code sample

```js
// with firebase-functions@^7 installed:
const test = require('firebase-functions-test')();
test.mockConfig({ slack: { url: 'https://...' } });
// throws: mockConfig() is not supported with firebase-functions v7+ because
// functions.config() was removed. Migrate to environment parameters using
// the params module.
```
